### PR TITLE
[WIP] Some quick fixes for redux/next.js

### DIFF
--- a/common/lib/with-redux-store.js
+++ b/common/lib/with-redux-store.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import initializeStore from '@stores';
+
+const isServer = typeof window === 'undefined';
+const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__';
+
+function getOrCreateStore(initialState) {
+  // Always make a new store if server, otherwise state is shared between requests
+  if (isServer) {
+    return initializeStore(initialState);
+  }
+
+  // Create store if unavailable on the client and set it on the window object
+  if (!window[__NEXT_REDUX_STORE__]) {
+    window[__NEXT_REDUX_STORE__] = initializeStore(initialState);
+  }
+  return window[__NEXT_REDUX_STORE__];
+}
+
+export default (App) => {
+  return class AppWithRedux extends React.Component {
+    static async getInitialProps(appContext) {
+      // Get or Create the store with `undefined` as initialState
+      // This allows you to set a custom default initialState
+      const data = appContext.ctx.query;
+      const reduxStore = getOrCreateStore(data);
+
+      // Provide the store to getInitialProps of pages
+      appContext.ctx.reduxStore = reduxStore;
+
+      let appProps = {};
+      if (typeof App.getInitialProps === 'function') {
+        appProps = await App.getInitialProps.call(App, appContext);
+      }
+
+      return {
+        ...appProps,
+        initialReduxState: reduxStore.getState(),
+      };
+    }
+
+    constructor(props) {
+      super(props);
+      this.reduxStore = getOrCreateStore(props.initialReduxState);
+    }
+
+    render() {
+      return <App {...this.props} reduxStore={this.reduxStore} />;
+    }
+  };
+};

--- a/components/app-details/index.js
+++ b/components/app-details/index.js
@@ -26,9 +26,12 @@ const App = {
     line-height: 20px;
     color: #002257;
     text-decoration: none;
+    display: flex;
+    align-items: center;
 
     svg {
       margin-right: 5px;
+      display: block;
     }
 
     &:hover {

--- a/components/featured/index.js
+++ b/components/featured/index.js
@@ -1,10 +1,14 @@
 import React from 'react';
-import styled from 'styled-components';
-import { wrapperStyles } from '@common/styles';
+import styled, { css } from 'styled-components';
 
 const StyledFeatured = styled.div`
   position: relative;
-  width: 100%
+  width: 100%;
+  ${({ padding }) =>
+    padding &&
+    css`
+      padding: ${padding};
+    `};
 `;
 
 const Wrapper = styled.div`
@@ -21,7 +25,7 @@ const Wrapper = styled.div`
 
 const TitleSection = styled.div`
   width: 100px;
-  background: linear-gradient(#0CCABA, #0C9AA6);
+  background: linear-gradient(#0ccaba, #0c9aa6);
   height: 260px;
   min-width: 145px;
   color: #fff;
@@ -43,12 +47,12 @@ const TitleSection = styled.div`
     min-height: 80px;
     height: auto;
   }
-`
+`;
 
 const Section = styled.div`
   width: 100%;
   display: flex;
-  flex-flow: row; 
+  flex-flow: row;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-around;
@@ -115,18 +119,18 @@ const NameLink = styled.a`
   color: #282f36;
   font-weight: 700;
   text-decoration: none;
-  padding-left:20px;
+  padding-left: 20px;
   &:hover {
     text-decoration: none;
   }
-`
+`;
 
 const Description = styled.p`
   padding: 5px 20px 5px 20px;
   margin: 0;
   font-size: 14px;
   color: #6c737a;
-`
+`;
 
 StyledFeatured.Wrapper = Wrapper;
 StyledFeatured.TitleSection = TitleSection;

--- a/containers/app-list/index.js
+++ b/containers/app-list/index.js
@@ -4,14 +4,12 @@ import Tooltip from '@atlaskit/tooltip';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Link from 'next/link';
-
 import { StyledAppList } from '@components/app-list';
 import { Button } from '@components/button';
-import { LinkButton } from '@components/link-button';
-import { DropdownButton } from '@containers/dropdown-button';
 import AppIcon from '@containers/app-icon';
-import { truncate, appRoute } from '@utils';
+import { appRoute, truncate } from '@utils';
 import AppStore from '@stores/apps';
+import { selectApps } from '@stores/apps/selectors';
 
 const SORT_METHOD = {
   TWEETS: { value: 0, name: 'Tweets / Week', description: '' },
@@ -203,7 +201,7 @@ class AppList extends React.Component {
 }
 
 const mapStateToProps = (state) => ({
-  apps: state.apps.apps,
+  apps: selectApps(state),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/containers/app-list/index.js
+++ b/containers/app-list/index.js
@@ -110,7 +110,7 @@ class AppList extends React.Component {
     const renderRows = () => {
       const visibleApps = showAll ? sortedApps : sortedApps.slice(0, showCount);
       return visibleApps.map((app, index) => (
-        <Link href={appRoute(app)}>
+        <Link href={appRoute(app)} key={app.id}>
           <StyledAppList.Row key={app.id}>
             <StyledAppList.Rank>{index + 1}</StyledAppList.Rank>
             <StyledAppList.Icon>{<AppIcon app={app} />}</StyledAppList.Icon>

--- a/containers/featured/index.js
+++ b/containers/featured/index.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import sortBy from 'lodash/sortBy';
 import Link from 'next/link';
-
+import { connect } from 'react-redux';
 import { StyledFeatured } from '@components/featured';
-import { StyledAppList } from '@components/app-list';
 import { colorHexFromString, appRoute } from '@utils';
 
-class Featured extends React.Component {
+import { selectApps } from '@stores/apps/selectors';
+
+class FeaturedContainer extends React.Component {
+  getFeaturedApps = (featured, apps) => (apps.length ? apps.filter((app) => featured.includes(app.name)) : null);
+
   constructor(props) {
     super(props);
 
@@ -19,11 +22,8 @@ class Featured extends React.Component {
     };
   }
 
-  getFeaturedApps(featured, apps) {
-    return apps.filter((app) => featured.includes(app.name));
-  }
-
   render() {
+    const { right, ...rest } = this.props;
     const appImage = (app) => {
       if (app.imageUrl) {
         return <StyledFeatured.IconImage src={app.imageUrl} />;
@@ -33,9 +33,9 @@ class Featured extends React.Component {
     };
 
     return (
-      <StyledFeatured>
+      <StyledFeatured {...rest}>
         <StyledFeatured.Wrapper>
-          {!this.props.right && (
+          {!right && (
             <StyledFeatured.TitleSection>
               Hot Social Dapps <br />
               <p>Our curated list of notable Dapps changing the way we communicate.</p>
@@ -59,7 +59,7 @@ class Featured extends React.Component {
               </Link>
             ))}
           </StyledFeatured.Section>
-          {this.props.right && (
+          {right && (
             <StyledFeatured.TitleSection>
               Business Tools<br />
               <p>Decentralize your workplace.</p>
@@ -70,5 +70,9 @@ class Featured extends React.Component {
     );
   }
 }
+const mapStateToProps = (state) => ({
+  apps: selectApps(state),
+});
+const Featured = connect(mapStateToProps)(FeaturedContainer);
 
 export { Featured };

--- a/containers/featured/index.js
+++ b/containers/featured/index.js
@@ -43,7 +43,7 @@ class FeaturedContainer extends React.Component {
           )}
           <StyledFeatured.Section>
             {this.state.featuredApps.map((app) => (
-              <Link href={appRoute(app)}>
+              <Link href={appRoute(app)} key={app.id}>
                 <StyledFeatured.Item key={app.id}>
                   <StyledFeatured.Icon>{appImage(app)}</StyledFeatured.Icon>
                   <div>

--- a/containers/newsletter-cta/index.js
+++ b/containers/newsletter-cta/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import Newsletter from '@components/newsletter-cta';
-import { selectNewsletterAPI } from '@stores/apps/selectors';
+import { selectApiServer } from '@stores/apps/selectors';
 
 import { connect } from 'react-redux';
 
 const mapStateToProps = (state) => ({
-  newsletterApi: selectNewsletterAPI(state),
+  newsletterApi: selectApiServer(state),
 });
 
 const EMAIL_REGEX = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;

--- a/containers/newsletter-cta/index.js
+++ b/containers/newsletter-cta/index.js
@@ -1,11 +1,16 @@
 import React from 'react';
-import { Page } from '@containers/page';
 import Newsletter from '@components/newsletter-cta';
-import { Button } from '@components/button';
+import { selectNewsletterAPI } from '@stores/apps/selectors';
+
+import { connect } from 'react-redux';
+
+const mapStateToProps = (state) => ({
+  newsletterApi: selectNewsletterAPI(state),
+});
 
 const EMAIL_REGEX = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 
-export default class NewsletterCTA extends React.Component {
+class NewsletterCTA extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -17,7 +22,7 @@ export default class NewsletterCTA extends React.Component {
   }
 
   submit() {
-    const url = `${this.props.apiServer}/api/subscribe`;
+    const url = `${this.props.newsletterApi}/api/subscribe`;
     const { email } = this.state;
     if (email.match(EMAIL_REGEX)) {
       const data = { email };
@@ -66,3 +71,5 @@ export default class NewsletterCTA extends React.Component {
     );
   }
 }
+
+export default connect(mapStateToProps)(NewsletterCTA);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,8 @@
 import App, { Container } from 'next/app';
 import React from 'react';
 import { withRouter } from 'next/router';
-import { createStore } from 'redux';
 import { Provider } from 'react-redux';
+import withReduxStore from '@common/lib/with-redux-store';
 
 import { Root } from '@containers/root';
 import Store from '@stores';
@@ -10,30 +10,15 @@ import Store from '@stores';
 import 'isomorphic-unfetch';
 
 class MyApp extends App {
-  static async getInitialProps({ Component, ctx }) {
-    let pageProps = {};
-
-    const data = ctx.query;
-
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx);
-    }
-
-    return {
-      pageProps,
-      data,
-    };
-  }
 
   render() {
-    const { Component, pageProps, data } = this.props;
-    const store = Store(data);
+    const { Component, pageProps, reduxStore } = this.props;
 
     return (
       <Container>
-        <Provider store={store}>
+        <Provider store={reduxStore}>
           <Root>
-            <Component {...pageProps} data={data} />
+            <Component {...pageProps} />
           </Root>
         </Provider>
       </Container>
@@ -41,4 +26,4 @@ class MyApp extends App {
   }
 }
 
-export default withRouter(MyApp);
+export default withRouter(withReduxStore(MyApp));

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -59,7 +59,7 @@ export default class MyDocument extends Document {
           <script
             dangerouslySetInnerHTML={{
               __html: `
-            window.dataLayer = window.dataLayer || []; function gtag() 
+            window.dataLayer = window.dataLayer || []; function gtag()
             \{ dataLayer.push(arguments); \}
             gtag('js', new Date()); gtag('config', 'UA-119163063-1');
           `,

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -10,6 +10,7 @@ import AppList from '@containers/admin/app-list';
 
 import AppStore from '@stores/apps';
 import UserStore from '@stores/user';
+import { selectApps, selectApiServer } from '@stores/apps/selectors';
 
 import 'isomorphic-unfetch';
 
@@ -56,8 +57,8 @@ class Admin extends React.Component {
 }
 
 const mapStateToProps = (state) => ({
-  apps: state.apps.apps,
-  apiServer: state.apps.apiServer,
+  apps: selectApps(state),
+  apiServer: selectApiServer(state),
   user: state.user,
 });
 

--- a/pages/app-details.js
+++ b/pages/app-details.js
@@ -1,20 +1,15 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import queryString from 'query-string';
-
+import { selectCurrentApp } from '@stores/apps/selectors';
 import Page, { Grid, GridColumn } from '@atlaskit/page';
-
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import faGithub from '@fortawesome/fontawesome-free-brands/faGithub';
-import faTwitter from '@fortawesome/fontawesome-free-brands/faTwitter';
-
+import Head from 'next/head';
+import { GithubCircleIcon, TwitterCircleIcon } from 'mdi-react';
 import { Page as Container } from '@containers/page';
 import { Header } from '@containers/header';
 import { Hero } from '@containers/hero';
 import AppIcon from '@containers/app-icon';
-
+import { doSelectApp } from '@stores/apps';
 import StyledApp from '@components/app-details';
 import { StyledAppList } from '@components/app-list';
 import { Button } from '@components/button';
@@ -25,17 +20,14 @@ import UserStore from '@stores/user';
 import { outboundLink } from '@utils';
 
 class AppDetails extends React.Component {
-  componentDidMount() {
-    const { pathname } = document.location;
-    const slug = pathname.split('/')[2];
-    this.props.selectApp(slug);
-  }
+  static getInitialProps({ req, reduxStore }) {
+    const {
+      params: { slug },
+    } = req;
 
-  componentWillReceiveProps(nextProps) {
-    if (!this.props.selectedApp && nextProps.selectedApp) {
-      const app = nextProps.selectedApp;
-      document.title = `${app.name} on App.co - The Universal Dapp Store`;
-    }
+    reduxStore.dispatch(doSelectApp(slug));
+
+    return { slug };
   }
 
   appDetails() {
@@ -70,22 +62,22 @@ class AppDetails extends React.Component {
               <br />
               {app.openSourceUrl &&
                 app.openSourceUrl.indexOf('github.com') !== -1 && (
-                  <div>
+                  <>
                     <StyledApp.BrandLink href={app.openSourceUrl} target="_blank">
-                      <FontAwesomeIcon icon={faGithub} />
+                      <GithubCircleIcon color="currentColor" />
                       View on Github
                     </StyledApp.BrandLink>
                     <br />
-                  </div>
+                  </>
                 )}
 
               {app.twitterHandle && (
-                <div>
+                <>
                   <StyledApp.BrandLink href={`https://twitter.com/${app.twitterHandle}`} target="_blank">
-                    <FontAwesomeIcon icon={faTwitter} />
+                    <TwitterCircleIcon color="currentColor" />
                     View on Twitter
                   </StyledApp.BrandLink>
-                </div>
+                </>
               )}
 
               <br />
@@ -99,42 +91,42 @@ class AppDetails extends React.Component {
             <GridColumn medium={6}>
               <StyledApp.MainSection>
                 {app.blockchain && (
-                  <div>
+                  <>
                     <StyledApp.TagLabel>Blockchain</StyledApp.TagLabel>
                     <StyledAppList.TagGroup left>
                       <StyledAppList.Tag left>{app.blockchain}</StyledAppList.Tag>
                     </StyledAppList.TagGroup>
                     <br />
-                  </div>
+                  </>
                 )}
 
                 {app.storageNetwork && (
-                  <div>
+                  <>
                     <StyledApp.TagLabel>Storage Network</StyledApp.TagLabel>
                     <StyledAppList.TagGroup left>
                       <StyledAppList.Tag left>{app.storageNetwork}</StyledAppList.Tag>
                     </StyledAppList.TagGroup>
                     <br />
-                  </div>
+                  </>
                 )}
 
                 {app.authentication && (
-                  <div>
+                  <>
                     <StyledApp.TagLabel>Authentication</StyledApp.TagLabel>
                     <StyledAppList.TagGroup left>
                       <StyledAppList.Tag left>{app.authentication}</StyledAppList.Tag>
                     </StyledAppList.TagGroup>
                     <br />
-                  </div>
+                  </>
                 )}
 
                 {app.category && (
-                  <div>
+                  <>
                     <StyledApp.TagLabel>Category</StyledApp.TagLabel>
                     <StyledAppList.TagGroup left>
                       <StyledAppList.Tag left>{app.category}</StyledAppList.Tag>
                     </StyledAppList.TagGroup>
-                  </div>
+                  </>
                 )}
               </StyledApp.MainSection>
             </GridColumn>
@@ -150,21 +142,23 @@ class AppDetails extends React.Component {
   }
 
   render() {
-    console.log('App details page', this.props);
     return (
-      <div>
+      <>
+        <Head>
+          <title>{this.props.selectedApp.name} on App.co - The Universal Dapp Store</title>
+        </Head>
         <Header />
         <Hero />
         <Container.Section wrap={1}>
           <Container.Section.Content>{this.props.selectedApp && this.appDetails()}</Container.Section.Content>
         </Container.Section>
-      </div>
+      </>
     );
   }
 }
 
 const mapStateToProps = (state) => ({
-  selectedApp: state.apps.selectedApp,
+  selectedApp: selectCurrentApp(state),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,17 +13,14 @@ const bizApps = ['Graphite', 'Aragon', 'Gitcoin', 'Bounty0x', 'adChain Registry'
 
 export default ({ data }) => (
   <Page>
-    <Header data={data} />
+    <Header />
     <Hero />
     <Page.Section wrap={1}>
       <Page.Section.Content>
-        <Featured apps={data.apps} featured={featuredApps} />
-        <br />
-        <br />
-        <Featured apps={data.apps} featured={bizApps} right />
+        <Featured featured={featuredApps} padding="0 0 20px 0" />
+        <Featured featured={bizApps} right />
       </Page.Section.Content>
     </Page.Section>
-
     <Page.Section wrap={1}>
       <Page.Section.Content>
         <AppList show={25} />
@@ -32,9 +29,8 @@ export default ({ data }) => (
         <SubmitDappCard />
       </Page.Sidebar> */}
     </Page.Section>
-
     <Page.Section wrap={1}>
-      <NewsletterCTA apiServer={data.apiServer} />
+      <NewsletterCTA />
     </Page.Section>
   </Page>
 );

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ async function renderAndCache(req, res, pagePath) {
   const key = getCacheKey(req);
 
   // If we have a page in the cache, let's serve it
-  if (ssrCache.has(key)) {
+  if (ssrCache.has(key) && !dev) {
     res.setHeader('x-cache', 'HIT');
     console.log('cache hit');
     res.send(ssrCache.get(key));

--- a/stores/apps/index.js
+++ b/stores/apps/index.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import assignIn from 'lodash/assignIn';
 
 const constants = {
@@ -24,21 +23,19 @@ const savedApp = (app) => ({
   type: constants.SAVED_APP,
   app,
 });
-const saveApp = (data, apiServer, jwt) =>
-  async function innerSaveApp(dispatch) {
-    console.log(data);
-    dispatch(savingApp());
-    const response = await fetch(`${apiServer}/api/admin/apps/${data.id}`, {
-      method: 'POST',
-      headers: new Headers({
-        Authorization: `Bearer ${jwt}`,
-        'Content-Type': 'application/json',
-      }),
-      body: JSON.stringify(data),
-    });
-    const { app } = await response.json();
-    dispatch(savedApp(app));
-  };
+const saveApp = (data, apiServer, jwt) => async (dispatch) => {
+  dispatch(savingApp());
+  const response = await fetch(`${apiServer}/api/admin/apps/${data.id}`, {
+    method: 'POST',
+    headers: new Headers({
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    }),
+    body: JSON.stringify(data),
+  });
+  const { app } = await response.json();
+  dispatch(savedApp(app));
+};
 
 const fetchingPending = () => ({
   type: constants.FETCHING_PENDING,
@@ -54,32 +51,28 @@ const fetchedAdminApps = (apps) => ({
   apps,
 });
 
-const fetchAdminApps = (apiServer, jwt) =>
-  async function innerFetchAdminApps(dispatch) {
-    const response = await fetch(`${apiServer}/api/admin/apps`, {
-      method: 'GET',
-      headers: new Headers({
-        Authorization: `Bearer ${jwt}`,
-        'Content-Type': 'application/json',
-      }),
-    });
-    const { apps } = await response.json();
-    dispatch(fetchedAdminApps(apps));
-  };
+const fetchAdminApps = (apiServer, jwt) => async (dispatch) => {
+  const response = await fetch(`${apiServer}/api/admin/apps`, {
+    method: 'GET',
+    headers: new Headers({
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    }),
+  });
+  const { apps } = await response.json();
+  dispatch(fetchedAdminApps(apps));
+};
 
-const fetchPendingApps = (apiServer, jwt) =>
-  async function innerFetchPendingApps(dispatch) {
-    dispatch(fetchingPending());
-    const response = await fetch(`${apiServer}/api/admin/apps/pending`, {
-      headers: new Headers({
-        Authorization: `Bearer ${jwt}`,
-      }),
-    });
-    // console.log(response.json());
-    const { apps } = await response.json();
-    console.log(apps);
-    dispatch(fetchedPending(apps));
-  };
+const fetchPendingApps = (apiServer, jwt) => async (dispatch) => {
+  dispatch(fetchingPending());
+  const response = await fetch(`${apiServer}/api/admin/apps/pending`, {
+    headers: new Headers({
+      Authorization: `Bearer ${jwt}`,
+    }),
+  });
+  const { apps } = await response.json();
+  dispatch(fetchedPending(apps));
+};
 
 const actions = {
   setPlatformFilter,
@@ -113,53 +106,57 @@ const makeReducer = (data) => {
   const reducer = (state = initialState, action) => {
     switch (action.type) {
       case constants.SET_PLATFORM:
-        return Object.assign({}, state, {
+        return {
+          ...state,
           platformFilter: action.platform,
-        });
+        };
       case constants.SELECT_APP: {
         const { id } = action;
-        let app = null;
+        let selectedApp = null;
         if (Number.isInteger(id)) {
-          app = state.apps.find((_app) => _app.id === id);
+          selectedApp = state.apps.find((_app) => _app.id === id);
         } else {
-          app = state.apps.find((_app) => {
+          selectedApp = state.apps.find((_app) => {
             const slug = _app.Slugs.find((_slug) => _slug.value === id);
             return !!slug;
           });
         }
-        return Object.assign({}, state, {
+        return {
+          ...state,
           selectedAppId: id,
-          selectedApp: app,
-        });
+          selectedApp,
+        };
       }
       case constants.SAVING_APP:
-        return Object.assign({}, state, {
+        return {
+          ...state,
           isSavingApp: true,
-        });
+        };
       case constants.SAVED_APP:
-        return Object.assign({}, state, {
+        return {
           isSavingApp: false,
           savedApp: action.app,
           selectedApp: action.app,
-        });
+        };
       case constants.FETCHING_PENDING:
         return Object.assign({}, state, {
           isFetchingPending: true,
         });
       case constants.FETCHED_PENDING:
-        return Object.assign({}, state, {
+        return {
+          ...state,
           isFetchingPending: false,
           pendingApps: action.apps,
-        });
+        };
       case constants.FETCHED_ADMIN_APPS: {
-        console.log('fetched admin apps');
         const newState = { apps: action.apps };
         if (state.selectedAppId) {
-          console.log('existing selectedApp', state.selectedApp);
-          newState.selectedApp = find(action.apps, (app) => app.id === state.selectedAppId);
-          console.log('new selectedApp', newState.selectedApp.status);
+          newState.selectedApp = action.apps.find((app) => app.id === state.selectedAppId);
         }
-        return Object.assign({}, state, newState);
+        return {
+          ...state,
+          ...newState,
+        };
       }
       default:
         return state;

--- a/stores/apps/index.js
+++ b/stores/apps/index.js
@@ -1,4 +1,5 @@
 import find from 'lodash/find';
+import assignIn from 'lodash/assignIn';
 
 const constants = {
   SET_PLATFORM: 'SET_PLATFORM',
@@ -91,15 +92,23 @@ const actions = {
 };
 
 const makeReducer = (data) => {
-  const initialState = Object.assign({}, data, {
-    platformFilter: null,
-    selectedApp: null,
-    selectedAppId: null,
-    isSavingApp: false,
-    savedApp: null,
-    isFetchingPending: false,
-    pendingApps: [],
-  });
+  let initialState = data;
+
+  if (initialState.apps.apps) {
+    initialState = initialState.apps;
+  } else {
+    const emptyState = {
+      platformFilter: null,
+      selectedApp: null,
+      selectedAppId: null,
+      isSavingApp: false,
+      savedApp: null,
+      isFetchingPending: false,
+      pendingApps: [],
+    };
+
+    initialState = assignIn(data, emptyState);
+  }
 
   const reducer = (state = initialState, action) => {
     switch (action.type) {

--- a/stores/apps/index.js
+++ b/stores/apps/index.js
@@ -14,7 +14,7 @@ const setPlatformFilter = (platform) => ({
   type: constants.SET_PLATFORM,
   platform,
 });
-const selectApp = (id) => ({
+export const doSelectApp = (id) => ({
   type: constants.SELECT_APP,
   id,
 });
@@ -82,7 +82,7 @@ const fetchPendingApps = (apiServer, jwt) =>
 
 const actions = {
   setPlatformFilter,
-  selectApp,
+  doSelectApp,
   savingApp,
   savedApp,
   saveApp,
@@ -108,14 +108,13 @@ const makeReducer = (data) => {
           platformFilter: action.platform,
         });
       case constants.SELECT_APP: {
-        console.log('select app');
         const { id } = action;
         let app = null;
-        if (typeof id === 'number') {
-          app = find(state.apps, (_app) => _app.id === id);
+        if (Number.isInteger(id)) {
+          app = state.apps.find((_app) => _app.id === id);
         } else {
-          app = find(state.apps, (_app) => {
-            const slug = find(_app.Slugs, (_slug) => _slug.value === id);
+          app = state.apps.find((_app) => {
+            const slug = _app.Slugs.find((_slug) => _slug.value === id);
             return !!slug;
           });
         }

--- a/stores/apps/selectors.js
+++ b/stores/apps/selectors.js
@@ -1,4 +1,4 @@
 // this should probs be renamed so it's not apps.apps
 export const selectApps = (state) => state.apps.apps.apps
-export const selectNewsletterAPI = (state) => state.apps.newsletterApi
+export const selectApiServer = (state) => state.apps.apiServer
 export const selectCurrentApp = (state) => state.apps.apps.selectedApp

--- a/stores/apps/selectors.js
+++ b/stores/apps/selectors.js
@@ -1,4 +1,4 @@
 // this should probs be renamed so it's not apps.apps
-export const selectApps = (state) => state.apps.apps.apps
-export const selectApiServer = (state) => state.apps.apiServer
-export const selectCurrentApp = (state) => state.apps.apps.selectedApp
+export const selectApps = (state) => state.apps.apps;
+export const selectApiServer = (state) => state.apps.apiServer;
+export const selectCurrentApp = (state) => state.apps.selectedApp;

--- a/stores/apps/selectors.js
+++ b/stores/apps/selectors.js
@@ -1,0 +1,4 @@
+// this should probs be renamed so it's not apps.apps
+export const selectApps = (state) => state.apps.apps.apps
+export const selectNewsletterAPI = (state) => state.apps.newsletterApi
+export const selectCurrentApp = (state) => state.apps.apps.selectedApp

--- a/stores/index.js
+++ b/stores/index.js
@@ -2,14 +2,13 @@ import thunk from 'redux-thunk';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 // import { persistReducer, persistStore } from 'redux-persist';
 // import storage from 'redux-persist/lib/storage';
-import persistState from 'redux-localstorage';
 
 import AppsStore from '@stores/apps';
 import UserStore from '@stores/user';
 
 export default (data) => {
   const composeEnhancers = (typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
-  const finalCreateStore = composeEnhancers(applyMiddleware(thunk), persistState(['user']))(createStore);
+  const finalCreateStore = composeEnhancers(applyMiddleware(thunk))(createStore);
 
   const Reducer = combineReducers({
     apps: AppsStore.makeReducer(data),

--- a/stores/index.js
+++ b/stores/index.js
@@ -2,13 +2,14 @@ import thunk from 'redux-thunk';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 // import { persistReducer, persistStore } from 'redux-persist';
 // import storage from 'redux-persist/lib/storage';
+import persistState from 'redux-localstorage';
 
 import AppsStore from '@stores/apps';
 import UserStore from '@stores/user';
 
 export default (data) => {
   const composeEnhancers = (typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
-  const finalCreateStore = composeEnhancers(applyMiddleware(thunk))(createStore);
+  const finalCreateStore = composeEnhancers(applyMiddleware(thunk), persistState(['user']))(createStore);
 
   const Reducer = combineReducers({
     apps: AppsStore.makeReducer(data),

--- a/stores/index.js
+++ b/stores/index.js
@@ -9,7 +9,8 @@ import UserStore from '@stores/user';
 
 export default (data) => {
   const composeEnhancers = (typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
-  const finalCreateStore = composeEnhancers(applyMiddleware(thunk), persistState(['user']))(createStore);
+  const persisted = persistState(['user'], { key: 'redux-app-co' });
+  const finalCreateStore = composeEnhancers(applyMiddleware(thunk), persisted)(createStore);
 
   const Reducer = combineReducers({
     apps: AppsStore.makeReducer(data),


### PR DESCRIPTION
I saw that some of the stuff we were doing was on the client rather than the server, so I went in and made some updates on how we're using redux and the SSR capabilities of next.js

This pull request does the following:

- abstracts out our redux store into a hoc and then provides that to each page
- calls some functions on the server now rather than the client (so that when you view a app-single page, the content will be there when the page loads rather than having to wait for it. This increases performance but also makes each page have better SEO)
- started abstracting out redux selectors into their own functions
- started replacing `div` wrappers with `<>` (react fragments)
- replaces FontAwesome Icons with `mdi-icons` (the font awesome icons were mis-sized on initial load because of a css race condition I think, where as the mdi-icons function correctly)