### PR TITLE
Adds Payout Animation

### DIFF
--- a/components/mining/shared/index.js
+++ b/components/mining/shared/index.js
@@ -129,27 +129,7 @@ const sizes = [1, 0.95, 0.9, 0.89]
 const opacity = [1, 0.46, 0.25, 0.15]
 const offset = [0, 21, 40, 60]
 
-const getActiveStyles = (active, index, length) => {
-  if (active === index) {
-    return {
-      zIndex: 20,
-      position: 'relative',
-      transform: `translateY(${offset[0]}px) scale(${sizes[0]})`,
-      opacity: opacity[0]
-    }
-  }
-  const number = index - active < 0 ? length + (index - active) : index - active
-  return {
-    position: 'absolute',
-    zIndex: length - index,
-    top: '0px',
-    transform: `translateY(${offset[number]}px) scale(${sizes[number]})`,
-    left: 0,
-    opacity: opacity[number]
-  }
-}
-
-const AppItem = ({ app, active, length, ...rest }) => (
+const AppItem = ({ app, ...rest }) => (
   <Flex
     alignItems="center"
     p={5}

--- a/components/mining/shared/index.js
+++ b/components/mining/shared/index.js
@@ -149,16 +149,18 @@ const getActiveStyles = (active, index, length) => {
   }
 }
 
-const AppItem = ({ app, active, index, length, ...rest }) => (
+const AppItem = ({ app, active, length, ...rest }) => (
   <Flex
     alignItems="center"
     p={5}
     bg="white"
+    position="absolute"
+    top="0"
+    left="0"
     width={1}
     borderRadius={4}
     boxShadow="card"
     {...rest}
-    {...getActiveStyles(active, index, length)}
     style={{
       transition: '0.5s all ease-in-out'
     }}
@@ -174,7 +176,6 @@ const AppItem = ({ app, active, index, length, ...rest }) => (
       style={{
         transition: '0.5s all ease-in-out'
       }}
-      opacity={index !== active ? 0 : 1}
     />
     <Box fontSize={3} pl={4} color="blue.dark">
       <Type fontWeight={400}>{app.name}</Type> <Type opacity={0.5}>earned</Type>{' '}

--- a/components/mining/svg.js
+++ b/components/mining/svg.js
@@ -317,17 +317,14 @@ const RegisterGraphic = ({ color = '#4410FF' }) => (
 
 const VerticalDotLine = ({ color = '#EF6F70' }) => (
   <svg width="3" height="33" viewbox="0 0 3 33" fill="none">
-  <rect fill={color} x="1" y="2" width="1" height="1"/>
-  <rect fill={color} x="1" y="5" width="1" height="1"/>
-  <rect fill={color} x="1" y="8" width="1" height="1"/>
-  <rect fill={color} x="1" y="11" width="1" height="1"/>
-  <rect fill={color} x="1" y="14" width="1" height="1"/>
-  <rect fill={color} x="1" y="17" width="1" height="1"/>
-  <rect fill={color} x="1" y="20" width="1" height="1"/>
-  <rect fill={color} x="1" y="23" width="1" height="1"/>
-  <rect fill={color} x="1" y="26" width="1" height="1"/>
-  <rect fill={color} x="1" y="29" width="1" height="1"/>
-  <rect fill={color} x="1" y="32" width="1" height="1"/>
+    <rect fill={color} x="1" y="2" width="1" height="1"/>
+    <rect fill={color} x="1" y="5" width="1" height="1"/>
+    <rect fill={color} x="1" y="8" width="1" height="1"/>
+    <rect fill={color} x="1" y="11" width="1" height="1"/>
+    <rect fill={color} x="1" y="14" width="1" height="1"/>
+    <rect fill={color} x="1" y="17" width="1" height="1"/>
+    <rect fill={color} x="1" y="20" width="1" height="1"/>
+    <rect fill={color} x="1" y="23" width="1" height="1"/>
   </svg>
 )
 

--- a/components/mining/svg.js
+++ b/components/mining/svg.js
@@ -316,7 +316,7 @@ const RegisterGraphic = ({ color = '#4410FF' }) => (
 )
 
 const VerticalDotLine = ({ color = '#EF6F70' }) => (
-  <svg width="3" height="108"viewbox="0 0 3 108" fill="none">
+  <svg width="3" height="33" viewbox="0 0 3 33" fill="none">
   <rect fill={color} x="1" y="2" width="1" height="1"/>
   <rect fill={color} x="1" y="5" width="1" height="1"/>
   <rect fill={color} x="1" y="8" width="1" height="1"/>
@@ -328,31 +328,6 @@ const VerticalDotLine = ({ color = '#EF6F70' }) => (
   <rect fill={color} x="1" y="26" width="1" height="1"/>
   <rect fill={color} x="1" y="29" width="1" height="1"/>
   <rect fill={color} x="1" y="32" width="1" height="1"/>
-  <rect fill={color} x="1" y="35" width="1" height="1"/>
-  <rect fill={color} x="1" y="38" width="1" height="1"/>
-  <rect fill={color} x="1" y="41" width="1" height="1"/>
-  <rect fill={color} x="1" y="44" width="1" height="1"/>
-  <rect fill={color} x="1" y="47" width="1" height="1"/>
-  <rect fill={color} x="1" y="50" width="1" height="1"/>
-  <rect fill={color} x="1" y="53" width="1" height="1"/>
-  <rect fill={color} x="1" y="56" width="1" height="1"/>
-  <rect fill={color} x="1" y="59" width="1" height="1"/>
-  <rect fill={color} x="1" y="62" width="1" height="1"/>
-  <rect fill={color} x="1" y="65" width="1" height="1"/>
-  <rect fill={color} x="1" y="68" width="1" height="1"/>
-  <rect fill={color} x="1" y="71" width="1" height="1"/>
-  <rect fill={color} x="1" y="74" width="1" height="1"/>
-  <rect fill={color} x="1" y="77" width="1" height="1"/>
-  <rect fill={color} x="1" y="80" width="1" height="1"/>
-  <rect fill={color} x="1" y="83" width="1" height="1"/>
-  <rect fill={color} x="1" y="86" width="1" height="1"/>
-  <rect fill={color} x="1" y="89" width="1" height="1"/>
-  <rect fill={color} x="1" y="92" width="1" height="1"/>
-  <rect fill={color} x="1" y="95" width="1" height="1"/>
-  <rect fill={color} x="1" y="98" width="1" height="1"/>
-  <rect fill={color} x="1" y="101" width="1" height="1"/>
-  <rect fill={color} x="1" y="104" width="1" height="1"/>
-  <rect fill={color} x="1" y="107" width="1" height="1"/>
   </svg>
 )
 

--- a/components/mining/svg.js
+++ b/components/mining/svg.js
@@ -315,6 +315,47 @@ const RegisterGraphic = ({ color = '#4410FF' }) => (
   </svg>
 )
 
+const VerticalDotLine = ({ color = '#EF6F70' }) => (
+  <svg width="3" height="108"viewbox="0 0 3 108" fill="none">
+  <rect fill={color} x="1" y="2" width="1" height="1"/>
+  <rect fill={color} x="1" y="5" width="1" height="1"/>
+  <rect fill={color} x="1" y="8" width="1" height="1"/>
+  <rect fill={color} x="1" y="11" width="1" height="1"/>
+  <rect fill={color} x="1" y="14" width="1" height="1"/>
+  <rect fill={color} x="1" y="17" width="1" height="1"/>
+  <rect fill={color} x="1" y="20" width="1" height="1"/>
+  <rect fill={color} x="1" y="23" width="1" height="1"/>
+  <rect fill={color} x="1" y="26" width="1" height="1"/>
+  <rect fill={color} x="1" y="29" width="1" height="1"/>
+  <rect fill={color} x="1" y="32" width="1" height="1"/>
+  <rect fill={color} x="1" y="35" width="1" height="1"/>
+  <rect fill={color} x="1" y="38" width="1" height="1"/>
+  <rect fill={color} x="1" y="41" width="1" height="1"/>
+  <rect fill={color} x="1" y="44" width="1" height="1"/>
+  <rect fill={color} x="1" y="47" width="1" height="1"/>
+  <rect fill={color} x="1" y="50" width="1" height="1"/>
+  <rect fill={color} x="1" y="53" width="1" height="1"/>
+  <rect fill={color} x="1" y="56" width="1" height="1"/>
+  <rect fill={color} x="1" y="59" width="1" height="1"/>
+  <rect fill={color} x="1" y="62" width="1" height="1"/>
+  <rect fill={color} x="1" y="65" width="1" height="1"/>
+  <rect fill={color} x="1" y="68" width="1" height="1"/>
+  <rect fill={color} x="1" y="71" width="1" height="1"/>
+  <rect fill={color} x="1" y="74" width="1" height="1"/>
+  <rect fill={color} x="1" y="77" width="1" height="1"/>
+  <rect fill={color} x="1" y="80" width="1" height="1"/>
+  <rect fill={color} x="1" y="83" width="1" height="1"/>
+  <rect fill={color} x="1" y="86" width="1" height="1"/>
+  <rect fill={color} x="1" y="89" width="1" height="1"/>
+  <rect fill={color} x="1" y="92" width="1" height="1"/>
+  <rect fill={color} x="1" y="95" width="1" height="1"/>
+  <rect fill={color} x="1" y="98" width="1" height="1"/>
+  <rect fill={color} x="1" y="101" width="1" height="1"/>
+  <rect fill={color} x="1" y="104" width="1" height="1"/>
+  <rect fill={color} x="1" y="107" width="1" height="1"/>
+  </svg>
+)
+
 const Dots = ({ color = '#EF6F70' }) => (
   <svg width="273" height="25" viewBox="0 0 273 25" fill="none">
     <path d="M1 4H0V5H1V4Z" fill={color} />
@@ -893,5 +934,6 @@ export {
   CameraIcon,
   Logo,
   TryMyUILogo,
-  OutlinedLogo
+  OutlinedLogo,
+  VerticalDotLine
 }

--- a/pages/mining/sections/hero/index.js
+++ b/pages/mining/sections/hero/index.js
@@ -36,7 +36,7 @@ const Apps = ({ apps, ...rest }) => {
   return (
     <State initial={{ active: 1, items }}>
       {({ state, setState }) => {
-        const handleClick = (curState) => {
+        const cycleItems = (curState) => {
           if (curState.active > limit) return setState({ active: 1});
 
           return setState({ active: curState.active + 1 });
@@ -58,13 +58,13 @@ const Apps = ({ apps, ...rest }) => {
               native
               items={displayData}
               keys={item => item.child.id}
-              initial={() => setTimeout(() => handleClick(state), 5000)}
+              initial={() => setTimeout(() => cycleItems(state), 5000)}
               from={{ opacity: 0, scale: 0 }}
               leave={{ opacity: 0, scale: 0 }}
               enter={({ opacity, scale, y }) => ({ opacity, scale, y })}
               update={({ opacity, scale, y }) => ({ opacity, scale, y })}
               trail={100}
-              onRest={() => setTimeout(() => handleClick(state), 5000)}
+              onRest={() => setTimeout(() => cycleItems(state), 5000)}
             >
               {({ child }, state, index) => ({ opacity, scale, y }) => (
                 <animated.div

--- a/pages/mining/sections/hero/index.js
+++ b/pages/mining/sections/hero/index.js
@@ -49,7 +49,7 @@ const Apps = ({ apps, ...rest }) => {
           const y = 20 * index;
           const opacity = 1 / (index + 1);
           const scale = 1 - (.05 * index);
-          return { child, index, opacity, scale, y };
+          return { child, opacity, scale, y };
         });
 
         return (
@@ -58,14 +58,11 @@ const Apps = ({ apps, ...rest }) => {
               native
               items={displayData}
               keys={item => item.child.id}
-              initial={null}
+              initial={() => setTimeout(() => handleClick(state), 5000)}
               from={{ opacity: 0, scale: 0 }}
               leave={{ opacity: 0, scale: 0 }}
               enter={({ opacity, scale, y }) => ({ opacity, scale, y })}
-              update={({ index, opacity, scale, y }) => ([
-                index === 2 ? { opacity: 0 } : { opacity },
-                { opacity, scale, y }
-              ])}
+              update={({ opacity, scale, y }) => ({ opacity, scale, y })}
               trail={100}
               onRest={() => setTimeout(() => handleClick(state), 5000)}
             >

--- a/pages/mining/sections/hero/index.js
+++ b/pages/mining/sections/hero/index.js
@@ -42,13 +42,14 @@ const Apps = ({ apps, ...rest }) => {
           return setState({ active: curState.active + 1 });
         };
 
-        const sortedItems = state.items.slice(state.active, state.items.length).concat(state.items.slice(0, state.active));
+        const { active, items } = state;
+        const sortedItems = items.slice(active, items.length).concat(items.slice(0, active));
 
         let displayData = sortedItems.map((child, index) => {
           const y = 20 * index;
           const opacity = 1 / (index + 1);
           const scale = 1 - (.05 * index);
-          return { opacity, scale, y, child, index };
+          return { child, index, opacity, scale, y };
         });
 
         return (
@@ -57,10 +58,14 @@ const Apps = ({ apps, ...rest }) => {
               native
               items={displayData}
               keys={item => item.child.id}
+              initial={null}
               from={{ opacity: 0, scale: 0 }}
               leave={{ opacity: 0, scale: 0 }}
               enter={({ opacity, scale, y }) => ({ opacity, scale, y })}
-              update={({ opacity, scale, y }) => ([{ opacity }, {scale, y}])}
+              update={({ index, opacity, scale, y }) => ([
+                index === 2 ? { opacity: 0 } : { opacity },
+                { opacity, scale, y }
+              ])}
               trail={100}
               onRest={() => setTimeout(() => handleClick(state), 5000)}
             >
@@ -73,7 +78,7 @@ const Apps = ({ apps, ...rest }) => {
                     transform: interpolate([scale, y], (scale, y) => `translateY(${y}px) scale(${scale})`)
                   }}
                 >
-                  <AppItem app={child } active={state.active} length={limit + 1} />
+                  <AppItem app={child } />
                 </animated.div>
               )}
             </Transition>

--- a/pages/mining/sections/hero/index.js
+++ b/pages/mining/sections/hero/index.js
@@ -13,7 +13,6 @@ import {
   CallToAction,
   SectionContext
 } from '@components/mining/shared'
-import { lerp } from '@utils';
 import { State } from 'react-powerplug'
 
 function arrayRotateOne(arr, reverse) {

--- a/pages/mining/sections/hero/index.js
+++ b/pages/mining/sections/hero/index.js
@@ -24,7 +24,6 @@ function arrayRotateOne(arr, reverse) {
 
 const Apps = ({ apps, ...rest }) => {
   const styles = {
-    outer: { width: 1 },
     cell: {
       position: 'absolute',
       willChange: 'transform, height, opacity',
@@ -53,7 +52,7 @@ const Apps = ({ apps, ...rest }) => {
         });
 
         return (
-          <Box {...styles.outer}>
+          <Box position='relative' width={1} {...rest}>
             <Transition
               native
               items={displayData}

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -1,10 +1,9 @@
 import React from 'react'
 import { Flex, Box, Type } from 'blockstack-ui'
-import { Transition, animated } from 'react-spring';
+import { Transition, animated, interpolate } from 'react-spring';
 import { Title, Wrapper, Section, ObservedSection } from '@components/mining/shared'
 import { Dots, DotsLine, DemoEarthLogo, ProductHuntLogo, CameraIcon, TryMyUILogo } from '@components/mining/svg'
-import { Hover } from 'react-powerplug'
-import { animated } from 'react-spring'
+import { Hover, State } from 'react-powerplug'
 
 const texts = [
   'Any app with Blockstack auth or storage can register for App Mining.',
@@ -82,113 +81,182 @@ const Ranker = ({ position, logo: Logo, children, color, logoProps = {}, ...rest
   </Hover>
 )
 
-const RankingSection = ({ apps, ...rest }) => (
-  <ObservedSection bg="blue.dark" {...rest}>
-    {({ inView }) => (
-      <Wrapper inView={inView} observed flexDirection="column">
-        <Flex width={1} flexShrink={1} flexDirection="column">
-          <Title maxWidth={'100%'}>Apps are ranked by expert reviewers</Title>
-          <Type pt={6} fontSize={3} color="white">
-            Rankings are combined and payouts sent every 30 days.
-          </Type>
-        </Flex>
-        <Flex
-          width={1}
-          alignItems="center"
-          justifyContent="center"
-          flexGrow={1}
-          flexDirection="column"
-          position="relative"
-          pt={7}
-        >
-          <Box width={1} borderRadius={4} overflow="hidden" style={{ willChange: 'transform' }}>
-            <Flex color={'blue.dark'} alignItems="center" bg="white" px={[4, 6]} py={6}>
-              <Flex alignItems="center">
-                <Type mr={4} fontSize={4} fontFamily="brand">
-                  1
-                </Type>
-                <Flex
-                  mr={4}
-                  size={72}
-                  border={1}
-                  borderColor="blue.dark"
-                  borderRadius={16}
-                  alignItems={'center'}
-                  justifyContent="center"
-                >
-                  <CameraIcon />
-                </Flex>
-              </Flex>
-              <Flex ml="auto">
-                <Type lineHeight={1.5} fontSize={5} fontWeight={300} fontFamily="brand">
-                  <Type opacity={0.5} fontWeight={['bold', 300]} fontSize={[2, 5]}>
-                    Payout this&nbsp;month:
-                  </Type>{' '}
-                  $100,000
-                </Type>
-              </Flex>
-            </Flex>
-            <Flex
-              overflow="hidden"
-              flexWrap="wrap"
-              lineHeight={1.5}
-              p={6}
-              bg="#081537"
-              position="relative"
-              pl={[5, 5, 5, 7]}
-              pr={5}
-              pt={[7, 7, 6, 6]}
+const RankingAnimation = ({ apps }) => {
+  const elementHeight = 136;
+  const animationData = [
+    {
+      id: 0,
+      image: CameraIcon,
+      payout: 20000
+    },
+    {
+      id: 1,
+      image: Dots,
+      payout: 16000
+    },
+    {
+      id: 2,
+      image: CameraIcon,
+      payout: 12800
+    }
+  ];
+
+  return (
+    <State initial={{ active: 0, animationData }}>
+      {({ state, setState }) => {
+        const cycleItems = (curState) => {
+          if (curState.active + 1 >= animationData.length) return setState({ active: 0 });
+
+          return setState({ active: curState.active + 1 });
+        };
+
+        const { active, animationData } = state;
+
+        return (
+          <Box
+            bg="white"
+            color={'blue.dark'}
+            height={136}
+          >
+            <Transition
+              native
+              items={[animationData[active]]}
+              keys={item => item.id}
+              from={{ opacity: 0, payout: 0, y: elementHeight }}
+              leave={{ opacity: 0, y: -elementHeight }}
+              enter={({ payout }) => ([{ opacity: 1, y: 0 }, { payout }])}
+              onRest={() => setTimeout(() => cycleItems(state), 5000)}
             >
-              <Ranker
-                is="a"
-                href="https://blog.producthunt.com/only-the-best-dapps-were-joining-blockstack-s-app-reviewer-program-%EF%B8%8F-6085bea0f501"
-                target="_blank"
-                logo={ProductHuntLogo}
-                mt={0}
-                color="#da552f"
-                position={-70}
-                logoProps={{
-                  minWidth: [180, 150, 150, 180]
-                }}
-              >
-                Ranks with Product Hunt
-                <Box is="br" display={['none', 'none', 'none', 'unset']} /> community upvotes and activity.
-              </Ranker>
-              <Ranker
-                is="a"
-                href="https://words.democracy.earth/democratic-app-ranking-democracy-earth-to-represent-blockstack-community-vote-on-app-mining-7ec8360bdc30"
-                target="_blank"
-                logo={DemoEarthLogo}
-                logoProps={{
-                  minWidth: [200, 152, 152, 200]
-                }}
-                color="#00c091"
-                position={-12}
-              >
-                Ranks by polling the Blockstack
-                <Box is="br" display={['none', 'none', 'none', 'unset']} /> investor community.
-              </Ranker>
-              <Ranker
-                is="a"
-                href="https://www.trymyui.com/blog/2019/01/09/trymyui-partners-with-blockstack-to-rate-blockchain-based-apps/"
-                target="_blank"
-                logo={TryMyUILogo}
-                color="#92c856"
-                position={-5}
-              >
-                Ranks by user testing
-                <Box is="br" display={['none', 'none', 'none', 'unset']} /> and usability metrics.
-              </Ranker>
-              <Box left={35} top={0} position="absolute">
-                <DotsLine />
-              </Box>
-            </Flex>
+              {(item, state, index) => ({ opacity, payout, y }) => (
+                <Flex
+                  is={animated.div}
+                  alignItems="center"
+                  flex={1}
+                  px={[4, 6]}
+                  py={6}
+                  style={{
+                    opacity,
+                    transform: y.interpolate((y) => `translateY(${y}px)`)
+                  }}
+                >
+                  <Type mr={4} fontSize={4} fontFamily="brand">
+                    {item.id + 1}
+                  </Type>
+                  <Flex
+                    mr={4}
+                    size={72}
+                    border={1}
+                    borderColor="blue.dark"
+                    borderRadius={16}
+                    alignItems={'center'}
+                    justifyContent="center"
+                  >
+                    {item.image}
+                  </Flex>
+                  <Flex ml="auto">
+                    <Type lineHeight={1.5} fontSize={5} fontWeight={300} fontFamily="brand">
+                      <Type opacity={0.5} fontWeight={['bold', 300]} fontSize={[2, 5]}>
+                        Payout this&nbsp;month:
+                      </Type>{' '}
+                      <Box is={animated.span}>
+                        {payout}
+                      </Box>
+                    </Type>
+                  </Flex>
+                </Flex>
+              )}
+            </Transition>
           </Box>
-          <TextSection />
-        </Flex>
-      </Wrapper>
-    )}
-  </ObservedSection>
-)
+        );
+      }}
+    </State>
+  );
+}
+
+const RankingSection = ({ apps, ...rest }) => {
+  return (
+    <ObservedSection bg="blue.dark" {...rest}>
+      {({ inView }) => (
+        <Wrapper inView={inView} observed flexDirection="column">
+          <Flex width={1} flexShrink={1} flexDirection="column">
+            <Title maxWidth={'100%'}>Apps are ranked by expert reviewers</Title>
+            <Type pt={6} fontSize={3} color="white">
+              Rankings are combined and payouts sent every 30 days.
+            </Type>
+          </Flex>
+          <Flex
+            width={1}
+            alignItems="center"
+            justifyContent="center"
+            flexGrow={1}
+            flexDirection="column"
+            position="relative"
+            pt={7}
+          >
+            <Box width={1} borderRadius={4} overflow="hidden" style={{ willChange: 'transform' }}>
+              <RankingAnimation apps={apps} />
+              <Flex
+                overflow="hidden"
+                flexWrap="wrap"
+                lineHeight={1.5}
+                p={6}
+                bg="#081537"
+                position="relative"
+                pl={[5, 5, 5, 7]}
+                pr={5}
+                pt={[7, 7, 6, 6]}
+              >
+                <Ranker
+                  is="a"
+                  href="https://blog.producthunt.com/only-the-best-dapps-were-joining-blockstack-s-app-reviewer-program-%EF%B8%8F-6085bea0f501"
+                  target="_blank"
+                  logo={ProductHuntLogo}
+                  mt={0}
+                  color="#da552f"
+                  position={-70}
+                  logoProps={{
+                    minWidth: [180, 150, 150, 180]
+                  }}
+                >
+                  Ranks with Product Hunt
+                  <Box is="br" display={['none', 'none', 'none', 'unset']} /> community upvotes and activity.
+                </Ranker>
+                <Ranker
+                  is="a"
+                  href="https://words.democracy.earth/democratic-app-ranking-democracy-earth-to-represent-blockstack-community-vote-on-app-mining-7ec8360bdc30"
+                  target="_blank"
+                  logo={DemoEarthLogo}
+                  logoProps={{
+                    minWidth: [200, 152, 152, 200]
+                  }}
+                  color="#00c091"
+                  position={-12}
+                >
+                  Ranks by polling the Blockstack
+                  <Box is="br" display={['none', 'none', 'none', 'unset']} /> investor community.
+                </Ranker>
+                <Ranker
+                  is="a"
+                  href="https://www.trymyui.com/blog/2019/01/09/trymyui-partners-with-blockstack-to-rate-blockchain-based-apps/"
+                  target="_blank"
+                  logo={TryMyUILogo}
+                  color="#92c856"
+                  position={-5}
+                >
+                  Ranks by user testing
+                  <Box is="br" display={['none', 'none', 'none', 'unset']} /> and usability metrics.
+                </Ranker>
+                <Box left={35} top={0} position="absolute">
+                  <DotsLine />
+                </Box>
+              </Flex>
+            </Box>
+            <TextSection />
+          </Flex>
+        </Wrapper>
+      )}
+    </ObservedSection>
+  );
+}
 
 export { RankingSection }

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Flex, Box, Type } from 'blockstack-ui'
+import { Transition, animated } from 'react-spring';
 import { Title, Wrapper, Section, ObservedSection } from '@components/mining/shared'
 import { Dots, DotsLine, DemoEarthLogo, ProductHuntLogo, CameraIcon, TryMyUILogo } from '@components/mining/svg'
 import { Hover } from 'react-powerplug'

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -78,7 +78,6 @@ const Ranker = ({ position, logo: Logo, children, color, logoProps = {}, ...rest
           {children}
         </Type>
         <GraphAnimation position={position} color={color} rows={5} count={100}/>
-      {/*  <DotsAnimation position={position} hovered={hovered} color={color} /> */}
       </Box>
     )}
   </Hover>
@@ -90,6 +89,15 @@ const GraphAnimation = ({ color, count, position, rows }) => {
     columnArray[i] = { key: i };
   }
 
+  const Animation = Keyframes.Trail(async next => {
+    while (true) {
+      await next({
+        from: { y: getRandomInt(0, 11) },
+        to: { y: getRandomInt(0, 11) }
+      })
+    };
+  })
+
   return (
     <Flex
       bottom={0}
@@ -100,19 +108,19 @@ const GraphAnimation = ({ color, count, position, rows }) => {
       top={0}
       zIndex={-1}
     >
-      <Trail
+      <Animation
         native
+        reset
         items={columnArray}
         keys={item => item.key}
-        from={{ y: 0 }}
-        to={(item) => { y: getRandomInt(0, 20) * 3 }}
+        config={{ duration: 1000 }}
       >
         {(item, index) => props => (
           <Flex
             is={animated.div}
             position='absolute'
             left={`${index * 5}px`}
-            top="40%"
+            bottom="-50%"
             width={5}
             height={100}
             style={{
@@ -122,7 +130,7 @@ const GraphAnimation = ({ color, count, position, rows }) => {
             <VerticalDotLine color={color} />
           </Flex>
         )}
-      </Trail>
+      </Animation>
     </Flex>
   )
 }

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -4,7 +4,7 @@ import { Flex, Box, Type } from 'blockstack-ui'
 import { Spring, Trail, Transition, animated, interpolate } from 'react-spring';
 import { Title, Wrapper, Section, ObservedSection } from '@components/mining/shared'
 import { Dots, DotsLine, DemoEarthLogo, ProductHuntLogo, CameraIcon, TryMyUILogo, VerticalDotLine } from '@components/mining/svg'
-import { getDecimalPlaces, getSeededRandom, getRandomInt } from '@utils';
+import { getSeededRandom, getRandomInt, numberWithCommas } from '@utils';
 import { Hover, State } from 'react-powerplug'
 
 const texts = [
@@ -209,7 +209,7 @@ const RankingAnimation = ({ activeItem, apps, items, onRest }) => {
                   Payout this&nbsp;month:
                 </Type>{' '}
                 <Box is={animated.div} display='inline-block' width={95}>
-                  {payout.interpolate(payout =>  `$${Math.floor(payout).toString()}`)}
+                  {payout.interpolate(payout =>  `$${numberWithCommas(Math.floor(payout))}`)}
                 </Box>
               </Type>
             </Flex>

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -69,15 +69,15 @@ const Ranker = ({ position, logo: Logo, children, color, logoProps = {}, ...rest
         {...bind}
         {...rest}
       >
-        {Logo ? (
-          <Box color="white" maxWidth={100} pb={2} {...logoProps}>
-            <Logo />
-          </Box>
-        ) : null}
-        <Type pb={2} pt={[2, 2, 0, 0]} color={color}>
-          {children}
-        </Type>
-        <GraphAnimation position={position} color={color} rows={5} count={60}/>
+          {Logo ? (
+            <Box color="white" maxWidth={100} pb={2} {...logoProps}>
+              <Logo />
+            </Box>
+          ) : null}
+          <Type pb={2} pt={[2, 2, 0, 0]} color={color}>
+            {children}
+          </Type>
+          <GraphAnimation position={position} color={color} rows={5} count={150}/>
       </Box>
     )}
   </Hover>
@@ -139,7 +139,7 @@ const GraphAnimation = ({ color, count, position, rows }) => {
             is={animated.div}
             position='absolute'
             left={`${index * 5}px`}
-            bottom="-50%"
+            bottom={"-50%"}
             width={5}
             height={100}
             style={{

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -245,7 +245,7 @@ const RankingAnimation = ({ apps }) => {
                       <Type opacity={0.5} fontWeight={['bold', 300]} fontSize={[2, 5]}>
                         Payout this&nbsp;month:
                       </Type>{' '}
-                      <Box is={animated.div} display='inline-block' width={85}>
+                      <Box is={animated.div} display='inline-block' width={95}>
                         {payout.interpolate(payout => {
                           const payoutStr = Math.floor(payout).toString();
                           return `$${payoutStr.padStart(5, '0')}`;

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -209,10 +209,7 @@ const RankingAnimation = ({ activeItem, apps, items, onRest }) => {
                   Payout this&nbsp;month:
                 </Type>{' '}
                 <Box is={animated.div} display='inline-block' width={95}>
-                  {payout.interpolate(payout => {
-                    const payoutStr = Math.floor(payout).toString();
-                    return `$${payoutStr.padStart(5, '0')}`;
-                  })}
+                  {payout.interpolate(payout =>  `$${Math.floor(payout).toString()}`)}
                 </Box>
               </Type>
             </Flex>

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -115,51 +115,43 @@ const GraphAnimation = ({ color, count, position, rows }) => {
   }
 
   return (
-    <State initial={{ reset: false }}>
-      {({ state, setState }) => {
-        const toggleAnimation = (reset) => setState({ reset });
-
-        return (
+    <Flex
+      bottom={0}
+      left={0}
+      overflow='hidden'
+      position='absolute'
+      right={0}
+      top={0}
+      zIndex={-1}
+    >
+      <DurationTrail
+        native
+        reset={true}
+        from={{ seed: 1 }}
+        to={{ seed: 100 }}
+        items={columnArray}
+        keys={columnArray.map(item => item.key)}
+        delay={0}
+        config={{ duration: 2200 }}
+      >
+        {columnArray.map((item, index) => props => (
           <Flex
-            bottom={0}
-            left={0}
-            overflow='hidden'
+            is={animated.div}
             position='absolute'
-            right={0}
-            top={0}
-            zIndex={-1}
+            left={`${index * 5}px`}
+            bottom="-50%"
+            width={5}
+            height={100}
+            style={{
+              transform: props.seed.interpolate(seed => `translate(0, ${getSeededRandom(item.seed + Math.floor(seed))}px)`)
+            }}
           >
-            <DurationTrail
-              native
-              reset={true}
-              from={{ seed: 1 }}
-              to={{ seed: 100 }}
-              items={columnArray}
-              keys={columnArray.map(item => item.key)}
-              delay={0}
-              config={{ duration: 2200 }}
-            >
-              {columnArray.map((item, index) => props => (
-                <Flex
-                  is={animated.div}
-                  position='absolute'
-                  left={`${index * 5}px`}
-                  bottom="-50%"
-                  width={5}
-                  height={100}
-                  style={{
-                    transform: props.seed.interpolate(seed => `translate(0, ${getSeededRandom(item.seed + Math.floor(seed))}px)`)
-                  }}
-                >
-                  <VerticalDotLine color={color} />
-                </Flex>
-              ))}
-            </DurationTrail>
+            <VerticalDotLine color={color} />
           </Flex>
-        )
-      }}
-    </State>
-  )
+        ))}
+      </DurationTrail>
+    </Flex>
+  );
 }
 
 const RankingAnimation = ({ activeItem, apps, items, onRest }) => {

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -1,10 +1,10 @@
 import { times } from 'lodash';
-import React from 'react'
+import React, { Fragment } from 'react'
 import { Flex, Box, Type } from 'blockstack-ui'
 import { Spring, Trail, Transition, animated, interpolate } from 'react-spring';
 import { Title, Wrapper, Section, ObservedSection } from '@components/mining/shared'
 import { Dots, DotsLine, DemoEarthLogo, ProductHuntLogo, CameraIcon, TryMyUILogo, VerticalDotLine } from '@components/mining/svg'
-import { getDecimalPlaces, getRandomInt } from '@utils';
+import { getDecimalPlaces, getSeededRandom, getRandomInt } from '@utils';
 import { Hover, State } from 'react-powerplug'
 
 const texts = [
@@ -81,28 +81,29 @@ const Ranker = ({ position, logo: Logo, children, color, logoProps = {}, ...rest
       </Box>
     )}
   </Hover>
-)
+);
 
-class DurationTrail extends React.Component {
-  getValues = () => this.ref.getValues();
-
-  render() {
-    const { children, delay = 0, ms = 50, keys, onRest, ...props } = this.props;
-
-    return children.map((child, i) => {
-      return (
-        <Spring
-          ref={ref => i === 0 && (this.ref = ref)}
-          key={keys[i]}
-          {...props}
-          delay={0}
-          onRest={i === children.length - 1 ? onRest : null}
-          children={child}
-        />
-      )
-    })
-  }
-}
+const DurationTrail = ({
+  children,
+  delay = 0,
+  keys,
+  ms = 50,
+  onRest,
+  ...props
+}) => (
+  <Fragment>
+    {children.map((child, i) => (
+      <Spring
+        {...props}
+        children={child}
+        delay={0}
+        key={keys[i]}
+        onRest={i === children.length - 1 ? onRest : null}
+      />
+    ))
+    }
+  </Fragment>
+);
 
 const GraphAnimation = ({ color, count, position, rows }) => {
   const columnArray = new Array(count);
@@ -111,16 +112,6 @@ const GraphAnimation = ({ color, count, position, rows }) => {
       key: i,
       seed: getRandomInt(0, count)
     };
-  }
-
-  const getSeededRandom = (seed = 0, max = 0, min = 11) => {
-    max = max || 1;
-    min = min || 0;
-
-    seed = (seed * 9301 + 49297) % 233280;
-    var rnd = seed / 233280;
-
-    return Math.floor(min + rnd * (max - min));
   }
 
   return (

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -199,7 +199,7 @@ const RankingAnimation = ({ apps }) => {
                       <Type opacity={0.5} fontWeight={['bold', 300]} fontSize={[2, 5]}>
                         Payout this&nbsp;month:
                       </Type>{' '}
-                      <Box is={animated.span}>
+                      <Box is={animated.div} display='inline-block' width={85}>
                         {payout.interpolate(payout => {
                           const payoutStr = Math.floor(payout).toString();
                           return payoutStr.padStart(6 - payoutStr.length, '0');

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -4,7 +4,7 @@ import { Flex, Box, Type } from 'blockstack-ui'
 import { Keyframes, Transition, animated, interpolate } from 'react-spring';
 import { Title, Wrapper, Section, ObservedSection } from '@components/mining/shared'
 import { Dots, DotsLine, DemoEarthLogo, ProductHuntLogo, CameraIcon, TryMyUILogo } from '@components/mining/svg'
-import { getRandomInt } from '@utils';
+import { getDecimalPlaces, getRandomInt } from '@utils';
 import { Hover, State } from 'react-powerplug'
 
 const texts = [
@@ -164,6 +164,7 @@ const RankingAnimation = ({ apps }) => {
               leave={{ opacity: 0, y: -elementHeight }}
               enter={({ payout }) => ([{ opacity: 1, y: 0 }, { payout }])}
               onRest={() => setTimeout(() => cycleItems(state), 5000)}
+              config={key => key === 'payout' ? { duration: 1500 } : {}}
             >
               {(item, state, index) => ({ opacity, payout, y }) => (
                 <Flex
@@ -191,7 +192,7 @@ const RankingAnimation = ({ apps }) => {
                     alignItems={'center'}
                     justifyContent="center"
                   >
-                    {item.image}
+                    <CameraIcon />
                   </Flex>
                   <Flex ml="auto">
                     <Type lineHeight={1.5} fontSize={5} fontWeight={300} fontFamily="brand">
@@ -199,7 +200,10 @@ const RankingAnimation = ({ apps }) => {
                         Payout this&nbsp;month:
                       </Type>{' '}
                       <Box is={animated.span}>
-                        {payout}
+                        {payout.interpolate(payout => {
+                          const payoutStr = Math.floor(payout).toString();
+                          return payoutStr.padStart(6 - payoutStr.length, '0');
+                        })}
                       </Box>
                     </Type>
                   </Flex>

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -1,8 +1,10 @@
+import { times } from 'lodash';
 import React from 'react'
 import { Flex, Box, Type } from 'blockstack-ui'
-import { Transition, animated, interpolate } from 'react-spring';
+import { Keyframes, Transition, animated, interpolate } from 'react-spring';
 import { Title, Wrapper, Section, ObservedSection } from '@components/mining/shared'
 import { Dots, DotsLine, DemoEarthLogo, ProductHuntLogo, CameraIcon, TryMyUILogo } from '@components/mining/svg'
+import { getRandomInt } from '@utils';
 import { Hover, State } from 'react-powerplug'
 
 const texts = [
@@ -75,11 +77,47 @@ const Ranker = ({ position, logo: Logo, children, color, logoProps = {}, ...rest
         <Type pb={2} pt={[2, 2, 0, 0]} color={color}>
           {children}
         </Type>
-        <DotsAnimation position={position} hovered={hovered} color={color} />
+        <GraphAnimation position={position} color={color} rows={5} count={10}/>
+      {/*  <DotsAnimation position={position} hovered={hovered} color={color} /> */}
       </Box>
     )}
   </Hover>
 )
+
+const GraphAnimation = ({ color, count, position, rows }) => {
+  const columnArray = new Array(count);
+
+  const ColumnAnimation = Keyframes.Spring(async next => {
+    while (true) {
+      await next({
+        from: { t: 0 },
+        to: { t: 1 }
+      });
+    }
+  });
+
+  return (
+    <Flex is={animated.div} position="absolute" bottom="-3px" style={{ transform: `translateX(${position}%)` }}>
+      <Box>
+        <ColumnAnimation
+          native
+          keys={columnArray}
+          config={{ duration: 200 }}
+        >
+          {items => props => (
+            <animated.div>
+              {times(count, () => {
+                return times(getRandomInt(0, rows), () => (
+                  <Box height={5} width={5} backgroundColor={color} />
+                ));
+              })}
+            </animated.div>
+          )}
+        </ColumnAnimation>
+      </Box>
+    </Flex>
+  )
+}
 
 const RankingAnimation = ({ apps }) => {
   const elementHeight = 136;
@@ -131,6 +169,8 @@ const RankingAnimation = ({ apps }) => {
                 <Flex
                   is={animated.div}
                   alignItems="center"
+                  position='absolute'
+                  width='100%'
                   flex={1}
                   px={[4, 6]}
                   py={6}

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -166,9 +166,77 @@ const GraphAnimation = ({ color, count, position, rows }) => {
   )
 }
 
-const RankingAnimation = ({ apps }) => {
+const RankingAnimation = ({ activeItem, apps, items, onRest }) => {
   const elementHeight = 136;
-  const animationData = [
+
+  return (
+    <Box
+      bg="white"
+      color={'blue.dark'}
+      height={136}
+    >
+      <Transition
+        native
+        items={[items[activeItem]]}
+        keys={item => item.id}
+        from={{ opacity: 0, payout: 0, y: elementHeight }}
+        leave={{ opacity: 0, y: -elementHeight }}
+        enter={({ payout }) => ([
+          { opacity: 1, y: 0 },
+          { payout, config: { duration: 1000 } }
+        ])}
+        onRest={() => setTimeout(onRest, 5000)}
+      >
+        {(item, state, index) => ({ opacity, payout, y }) => (
+          <Flex
+            is={animated.div}
+            alignItems="center"
+            position='absolute'
+            width='100%'
+            flex={1}
+            px={[4, 6]}
+            py={6}
+            style={{
+              opacity,
+              transform: y.interpolate((y) => `translateY(${y}px)`)
+            }}
+          >
+            <Type mr={4} fontSize={4} fontFamily="brand">
+              {item.id + 1}
+            </Type>
+            <Flex
+              mr={4}
+              size={72}
+              border={1}
+              borderColor="blue.dark"
+              borderRadius={16}
+              alignItems={'center'}
+              justifyContent="center"
+            >
+              <CameraIcon />
+            </Flex>
+            <Flex ml="auto">
+              <Type lineHeight={1.5} fontSize={5} fontWeight={300} fontFamily="brand">
+                <Type opacity={0.5} fontWeight={['bold', 300]} fontSize={[2, 5]}>
+                  Payout this&nbsp;month:
+                </Type>{' '}
+                <Box is={animated.div} display='inline-block' width={95}>
+                  {payout.interpolate(payout => {
+                    const payoutStr = Math.floor(payout).toString();
+                    return `$${payoutStr.padStart(5, '0')}`;
+                  })}
+                </Box>
+              </Type>
+            </Flex>
+          </Flex>
+        )}
+      </Transition>
+    </Box>
+  );
+}
+
+const RankingSection = ({ apps, ...rest }) => {
+  const carouselData = [
     {
       id: 0,
       payout: 20000
@@ -183,87 +251,6 @@ const RankingAnimation = ({ apps }) => {
     }
   ];
 
-  return (
-    <State initial={{ active: 0, animationData }}>
-      {({ state, setState }) => {
-        const cycleItems = (curState) => {
-          if (curState.active + 1 >= animationData.length) return setState({ active: 0 });
-
-          return setState({ active: curState.active + 1 });
-        };
-
-        const { active, animationData } = state;
-
-        return (
-          <Box
-            bg="white"
-            color={'blue.dark'}
-            height={136}
-          >
-            <Transition
-              native
-              items={[animationData[active]]}
-              keys={item => item.id}
-              from={{ opacity: 0, payout: 0, y: elementHeight }}
-              leave={{ opacity: 0, y: -elementHeight }}
-              enter={({ payout }) => ([
-                { opacity: 1, y: 0 },
-                { payout, config: { duration: 1000 } }
-              ])}
-              onRest={() => setTimeout(() => cycleItems(state), 5000)}
-            >
-              {(item, state, index) => ({ opacity, payout, y }) => (
-                <Flex
-                  is={animated.div}
-                  alignItems="center"
-                  position='absolute'
-                  width='100%'
-                  flex={1}
-                  px={[4, 6]}
-                  py={6}
-                  style={{
-                    opacity,
-                    transform: y.interpolate((y) => `translateY(${y}px)`)
-                  }}
-                >
-                  <Type mr={4} fontSize={4} fontFamily="brand">
-                    {item.id + 1}
-                  </Type>
-                  <Flex
-                    mr={4}
-                    size={72}
-                    border={1}
-                    borderColor="blue.dark"
-                    borderRadius={16}
-                    alignItems={'center'}
-                    justifyContent="center"
-                  >
-                    <CameraIcon />
-                  </Flex>
-                  <Flex ml="auto">
-                    <Type lineHeight={1.5} fontSize={5} fontWeight={300} fontFamily="brand">
-                      <Type opacity={0.5} fontWeight={['bold', 300]} fontSize={[2, 5]}>
-                        Payout this&nbsp;month:
-                      </Type>{' '}
-                      <Box is={animated.div} display='inline-block' width={95}>
-                        {payout.interpolate(payout => {
-                          const payoutStr = Math.floor(payout).toString();
-                          return `$${payoutStr.padStart(5, '0')}`;
-                        })}
-                      </Box>
-                    </Type>
-                  </Flex>
-                </Flex>
-              )}
-            </Transition>
-          </Box>
-        );
-      }}
-    </State>
-  );
-}
-
-const RankingSection = ({ apps, ...rest }) => {
   return (
     <ObservedSection bg="blue.dark" {...rest}>
       {({ inView }) => (
@@ -283,64 +270,85 @@ const RankingSection = ({ apps, ...rest }) => {
             position="relative"
             pt={7}
           >
-            <Box width={1} borderRadius={4} overflow="hidden" style={{ willChange: 'transform' }}>
-              <RankingAnimation apps={apps} />
-              <Flex
-                overflow="hidden"
-                flexWrap="wrap"
-                lineHeight={1.5}
-                p={6}
-                bg="#081537"
-                position="relative"
-                pl={[5, 5, 5, 7]}
-                pr={5}
-                pt={[7, 7, 6, 6]}
-              >
-                <Ranker
-                  is="a"
-                  href="https://blog.producthunt.com/only-the-best-dapps-were-joining-blockstack-s-app-reviewer-program-%EF%B8%8F-6085bea0f501"
-                  target="_blank"
-                  logo={ProductHuntLogo}
-                  mt={0}
-                  color="#da552f"
-                  position={-70}
-                  logoProps={{
-                    minWidth: [180, 150, 150, 180]
-                  }}
-                >
-                  Ranks with Product Hunt
-                  <Box is="br" display={['none', 'none', 'none', 'unset']} /> community upvotes and activity.
-                </Ranker>
-                <Ranker
-                  is="a"
-                  href="https://words.democracy.earth/democratic-app-ranking-democracy-earth-to-represent-blockstack-community-vote-on-app-mining-7ec8360bdc30"
-                  target="_blank"
-                  logo={DemoEarthLogo}
-                  logoProps={{
-                    minWidth: [200, 152, 152, 200]
-                  }}
-                  color="#00c091"
-                  position={-12}
-                >
-                  Ranks by polling the Blockstack
-                  <Box is="br" display={['none', 'none', 'none', 'unset']} /> investor community.
-                </Ranker>
-                <Ranker
-                  is="a"
-                  href="https://www.trymyui.com/blog/2019/01/09/trymyui-partners-with-blockstack-to-rate-blockchain-based-apps/"
-                  target="_blank"
-                  logo={TryMyUILogo}
-                  color="#92c856"
-                  position={-5}
-                >
-                  Ranks by user testing
-                  <Box is="br" display={['none', 'none', 'none', 'unset']} /> and usability metrics.
-                </Ranker>
-                <Box left={35} top={0} position="absolute">
-                  <DotsLine />
-                </Box>
-              </Flex>
-            </Box>
+            <State initial={{ activeCarouselItem: 0 }}>
+              {({ state, setState }) => {
+                const cycleItems = () => {
+                  if (curState.activeCarouselItem + 1 >= carouselData.length) {
+                    return setState({ activeCarouselItem: 0 });
+                  }
+
+                  return setState({
+                    activeCarouselItem: state.activeCarouselItem + 1
+                  });
+                };
+
+                return (
+                  <Box width={1} borderRadius={4} overflow="hidden" style={{ willChange: 'transform' }}>
+                    <RankingAnimation
+                      activeItem={state.activeCarouselItem}
+                      items={carouselData}
+                      apps={apps}
+                      onRest={cycleItems}
+                    />
+                    <Flex
+                      overflow="hidden"
+                      flexWrap="wrap"
+                      lineHeight={1.5}
+                      p={6}
+                      bg="#081537"
+                      position="relative"
+                      pl={[5, 5, 5, 7]}
+                      pr={5}
+                      pt={[7, 7, 6, 6]}
+                    >
+                      <Ranker
+                        is="a"
+                        href="https://blog.producthunt.com/only-the-best-dapps-were-joining-blockstack-s-app-reviewer-program-%EF%B8%8F-6085bea0f501"
+                        target="_blank"
+                        logo={ProductHuntLogo}
+                        mt={0}
+                        color="#da552f"
+                        position={-70}
+                        logoProps={{
+                          minWidth: [180, 150, 150, 180]
+                        }}
+                      >
+                        Ranks with Product Hunt
+                        <Box is="br" display={['none', 'none', 'none', 'unset']} /> community upvotes and activity.
+                      </Ranker>
+                      <Ranker
+                        is="a"
+                        href="https://words.democracy.earth/democratic-app-ranking-democracy-earth-to-represent-blockstack-community-vote-on-app-mining-7ec8360bdc30"
+                        target="_blank"
+                        logo={DemoEarthLogo}
+                        logoProps={{
+                          minWidth: [200, 152, 152, 200]
+                        }}
+                        color="#00c091"
+                        position={-12}
+                      >
+                        Ranks by polling the Blockstack
+                        <Box is="br" display={['none', 'none', 'none', 'unset']} /> investor community.
+                      </Ranker>
+                      <Ranker
+                        is="a"
+                        href="https://www.trymyui.com/blog/2019/01/09/trymyui-partners-with-blockstack-to-rate-blockchain-based-apps/"
+                        target="_blank"
+                        logo={TryMyUILogo}
+                        color="#92c856"
+                        position={-5}
+                      >
+                        Ranks by user testing
+                        <Box is="br" display={['none', 'none', 'none', 'unset']} /> and usability metrics.
+                      </Ranker>
+                      <Box left={35} top={0} position="absolute">
+                        <DotsLine />
+                      </Box>
+                    </Flex>
+                  </Box>
+                );
+              }}
+            </State>
             <TextSection />
           </Flex>
         </Wrapper>

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -133,11 +133,11 @@ const GraphAnimation = ({ color, count, position, rows }) => {
               native
               reset={true}
               from={{ seed: 1 }}
-              to={{ seed: 500 }}
+              to={{ seed: 100 }}
               items={columnArray}
               keys={columnArray.map(item => item.key)}
               delay={0}
-              config={{ duration: 3000 }}
+              config={{ duration: 2500 }}
             >
               {columnArray.map((item, index) => props => (
                 <Flex

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -140,7 +140,7 @@ const GraphAnimation = ({ color, count, position, rows }) => {
               config={{ duration: 3000 }}
               onRest={() => {
                 toggleAnimation(false);
-                setTimeout(() => toggleAnimation(true), 4000);
+                setTimeout(() => toggleAnimation(true), 5000);
               }}
             >
               {columnArray.map((item, index) => props => (

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -138,10 +138,6 @@ const GraphAnimation = ({ color, count, position, rows }) => {
               keys={columnArray.map(item => item.key)}
               delay={0}
               config={{ duration: 3000 }}
-              onRest={() => {
-                toggleAnimation(false);
-                setTimeout(() => toggleAnimation(true), 5000);
-              }}
             >
               {columnArray.map((item, index) => props => (
                 <Flex
@@ -273,7 +269,7 @@ const RankingSection = ({ apps, ...rest }) => {
             <State initial={{ activeCarouselItem: 0 }}>
               {({ state, setState }) => {
                 const cycleItems = () => {
-                  if (curState.activeCarouselItem + 1 >= carouselData.length) {
+                  if (state.activeCarouselItem + 1 >= carouselData.length) {
                     return setState({ activeCarouselItem: 0 });
                   }
 

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -171,17 +171,14 @@ const RankingAnimation = ({ apps }) => {
   const animationData = [
     {
       id: 0,
-      image: CameraIcon,
       payout: 20000
     },
     {
       id: 1,
-      image: Dots,
       payout: 16000
     },
     {
       id: 2,
-      image: CameraIcon,
       payout: 12800
     }
   ];
@@ -251,7 +248,7 @@ const RankingAnimation = ({ apps }) => {
                       <Box is={animated.div} display='inline-block' width={85}>
                         {payout.interpolate(payout => {
                           const payoutStr = Math.floor(payout).toString();
-                          return `$${payoutStr.padStart(6 - payoutStr.length, '0')}`;
+                          return `$${payoutStr.padStart(5, '0')}`;
                         })}
                       </Box>
                     </Type>

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -131,7 +131,7 @@ const GraphAnimation = ({ color, count, position, rows }) => {
           >
             <DurationTrail
               native
-              reset={state.reset}
+              reset={true}
               from={{ seed: 1 }}
               to={{ seed: 500 }}
               items={columnArray}

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -94,11 +94,11 @@ const DurationTrail = ({
   <Fragment>
     {children.map((child, i) => (
       <Spring
-        {...props}
         children={child}
         delay={0}
         key={keys[i]}
         onRest={i === children.length - 1 ? onRest : null}
+        {...props}
       />
     ))
     }
@@ -115,41 +115,54 @@ const GraphAnimation = ({ color, count, position, rows }) => {
   }
 
   return (
-    <Flex
-      bottom={0}
-      left={0}
-      overflow='hidden'
-      position='absolute'
-      right={0}
-      top={0}
-      zIndex={-1}
-    >
-      <DurationTrail
-        native
-        from={{ seed: 1 }}
-        to={{ seed: 500 }}
-        items={columnArray}
-        keys={columnArray.map(item => item.key)}
-        delay={0}
-        config={{ duration: 3000 }}
-      >
-        {columnArray.map((item, index) => props => (
+    <State initial={{ reset: false }}>
+      {({ state, setState }) => {
+        const toggleAnimation = (reset) => setState({ reset });
+
+        return (
           <Flex
-            is={animated.div}
+            bottom={0}
+            left={0}
+            overflow='hidden'
             position='absolute'
-            left={`${index * 5}px`}
-            bottom="-50%"
-            width={5}
-            height={100}
-            style={{
-              transform: props.seed.interpolate(seed => `translate(0, ${getSeededRandom(item.seed + Math.floor(seed))}px)`)
-            }}
+            right={0}
+            top={0}
+            zIndex={-1}
           >
-            <VerticalDotLine color={color} />
+            <DurationTrail
+              native
+              reset={state.reset}
+              from={{ seed: 1 }}
+              to={{ seed: 500 }}
+              items={columnArray}
+              keys={columnArray.map(item => item.key)}
+              delay={0}
+              config={{ duration: 3000 }}
+              onRest={() => {
+                toggleAnimation(false);
+                setTimeout(() => toggleAnimation(true), 4000);
+              }}
+            >
+              {columnArray.map((item, index) => props => (
+                <Flex
+                  is={animated.div}
+                  position='absolute'
+                  left={`${index * 5}px`}
+                  bottom="-50%"
+                  width={5}
+                  height={100}
+                  style={{
+                    transform: props.seed.interpolate(seed => `translate(0, ${getSeededRandom(item.seed + Math.floor(seed))}px)`)
+                  }}
+                >
+                  <VerticalDotLine color={color} />
+                </Flex>
+              ))}
+            </DurationTrail>
           </Flex>
-        ))}
-      </DurationTrail>
-    </Flex>
+        )
+      }}
+    </State>
   )
 }
 

--- a/pages/mining/sections/ranking/index.js
+++ b/pages/mining/sections/ranking/index.js
@@ -137,7 +137,7 @@ const GraphAnimation = ({ color, count, position, rows }) => {
               items={columnArray}
               keys={columnArray.map(item => item.key)}
               delay={0}
-              config={{ duration: 2500 }}
+              config={{ duration: 2200 }}
             >
               {columnArray.map((item, index) => props => (
                 <Flex

--- a/utils/index.js
+++ b/utils/index.js
@@ -32,20 +32,6 @@ const truncate = (str, options) => {
   return str
 }
 
-/**
- * Linearly interpolates between two values
- *
- * @method lerp
- * @param  {Number} v0      the starting value to interpolate
- * @param  {Number} v1      the ending value to interpolate
- * @param  {Number} t   the change to interpolate at
- * @return {Number}         the value at alpha
- **/
-const lerp = (v0, v1, t) => {
-  return v0 * (1 - t) + v1 * t;
-};
-
-
 const outboundLink = (app, link) => {
   if (typeof gtag !== 'undefined') {
     gtag('event', 'outgoing_click', {
@@ -169,6 +155,10 @@ const monthName = (month) => {
   return date.format('MMMM YYYY')
 }
 
+const getRandomInt = (min, max) => {
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
 export {
   appRoute,
   appStatuses,
@@ -176,9 +166,9 @@ export {
   capitalize,
   colorHexFromString,
   enumSelect,
+  getRandomInt,
   getTags,
   getTwitterMentions,
-  lerp,
   monthName,
   outboundLink,
   properTagFromParam,

--- a/utils/index.js
+++ b/utils/index.js
@@ -32,6 +32,20 @@ const truncate = (str, options) => {
   return str
 }
 
+/**
+ * Linearly interpolates between two values
+ *
+ * @method lerp
+ * @param  {Number} v0      the starting value to interpolate
+ * @param  {Number} v1      the ending value to interpolate
+ * @param  {Number} t   the change to interpolate at
+ * @return {Number}         the value at alpha
+ **/
+const lerp = (v0, v1, t) => {
+  return v0 * (1 - t) + v1 * t;
+};
+
+
 const outboundLink = (app, link) => {
   if (typeof gtag !== 'undefined') {
     gtag('event', 'outgoing_click', {
@@ -156,20 +170,21 @@ const monthName = (month) => {
 }
 
 export {
-  colorHexFromString,
-  truncate,
-  outboundLink,
-  enumSelect,
+  appRoute,
   appStatuses,
   appStatusFromValue,
-  appRoute,
   capitalize,
+  colorHexFromString,
+  enumSelect,
   getTags,
-  slugifyCategory,
-  properTagFromParam,
   getTwitterMentions,
+  lerp,
   monthName,
-  trackPageView,
+  outboundLink,
+  properTagFromParam,
+  slugify,
+  slugifyCategory,
   trackEvent,
-  slugify
+  trackPageView,
+  truncate
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -166,10 +166,11 @@ const getSeededRandom = (seed = 0, min = 0, max = 11) => {
   return Math.floor(min + rnd * (max - min));
 }
 
-const getDecimalPlaces = (value) => {
-  if(Math.floor(value) === value) return 0;
-  return value.toString().split(".")[1].length || 0;
-}
+const numberWithCommas = (x) => {
+  const parts = x.toString().split(".");
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return parts.join(".");
+};
 
 export {
   appRoute,
@@ -178,12 +179,12 @@ export {
   capitalize,
   colorHexFromString,
   enumSelect,
-  getDecimalPlaces,
   getSeededRandom,
   getRandomInt,
   getTags,
   getTwitterMentions,
   monthName,
+  numberWithCommas,
   outboundLink,
   properTagFromParam,
   slugify,

--- a/utils/index.js
+++ b/utils/index.js
@@ -159,6 +159,11 @@ const getRandomInt = (min, max) => {
   return Math.floor(Math.random() * (max - min)) + min;
 }
 
+const getDecimalPlaces = (value) => {
+  if(Math.floor(value) === value) return 0;
+  return value.toString().split(".")[1].length || 0;
+}
+
 export {
   appRoute,
   appStatuses,
@@ -166,6 +171,7 @@ export {
   capitalize,
   colorHexFromString,
   enumSelect,
+  getDecimalPlaces,
   getRandomInt,
   getTags,
   getTwitterMentions,

--- a/utils/index.js
+++ b/utils/index.js
@@ -159,6 +159,13 @@ const getRandomInt = (min, max) => {
   return Math.floor(Math.random() * (max - min)) + min;
 }
 
+const getSeededRandom = (seed = 0, min = 0, max = 11) => {
+  seed = (seed * 9301 + 49297) % 233280;
+  const rnd = seed / 233280;
+
+  return Math.floor(min + rnd * (max - min));
+}
+
 const getDecimalPlaces = (value) => {
   if(Math.floor(value) === value) return 0;
   return value.toString().split(".")[1].length || 0;
@@ -172,6 +179,7 @@ export {
   colorHexFromString,
   enumSelect,
   getDecimalPlaces,
+  getSeededRandom,
   getRandomInt,
   getTags,
   getTwitterMentions,


### PR DESCRIPTION
![2019-02-26 12 23 44](https://user-images.githubusercontent.com/3649828/53433026-9dc64980-39c1-11e9-92f8-908de76c6d9e.gif)

Adds two animations to mining page.

## 1: Carousel
Adds a looping carousel of payouts to the header of the ranking section. This pulls from `animationData`  collection inside the `RankingAnimation` stateless component. It uses a `Transition` component. The active element is rendered as a child, and animated in and out.

## 2: Calculating
Adds a looping dot calculation animation to the body of the ranking section. This pulls from `columnArray` inside the `GraphAnimation` component. It animates a series of vertical dot SVGs. It does this by utilizing a `getSeededRandom` function, and animating the seed, plus a random starting position. The seed is floored, so that it will only animate a change when the seed increments by an integer. This allows the speed of the animation to be controlled by the delta of the seed `from` and `to`. These SVGs are placed into a custom animation component, `DurationTrail` which allows all the SVG children to animate at the same time (rather than the native React-Spring `Trail` component which forces a delay between children).

### Todo:

* ~Improve timing between carousel and dots~
* Fix bug where hovering a Reviewer element throws off timing
* Add unique icons to carousel items (need assets)
