### PR TITLE
Adds caching to app mining apps on SSR

### DIFF
--- a/common/lib/api.js
+++ b/common/lib/api.js
@@ -5,6 +5,7 @@ const { ssrCache } = require('./cache')
 
 const dev = process.env.NODE_ENV !== 'production'
 const API_CACHE_KEY = 'API_CACHE_KEY'
+const BLOCKSTACK_RANKED_APPS_KEY = 'BLOCKSTACK_RANKED_APPS_KEY'
 
 const processApps = (appsData) => {
   let categories = Object.keys(appsData.constants.appConstants.categoryEnums)
@@ -74,7 +75,26 @@ const getAppMiningMonths = (apiServer) =>
     }  
   })
 
+const getRankedBlockstackApps = async (api) => {
+  try {
+    if (ssrCache.has(BLOCKSTACK_RANKED_APPS_KEY) && !dev) {
+      return JSON.parse(ssrCache.get(BLOCKSTACK_RANKED_APPS_KEY))
+    }
+    const months = await getAppMiningMonths(api)
+
+    const rankings = months[months.length - 1].compositeRankings
+
+    ssrCache.set(BLOCKSTACK_RANKED_APPS_KEY, JSON.stringify(rankings))
+    return rankings
+  } catch (error) {
+    console.error('error when fetching ranked apps', error)
+    return []
+  }
+  
+}
+
 module.exports = {
   getApps,
-  getAppMiningMonths
+  getAppMiningMonths,
+  getRankedBlockstackApps
 }

--- a/pages/home/index.js
+++ b/pages/home/index.js
@@ -7,37 +7,12 @@ import { doSelectApp } from '@stores/apps'
 import { PlatformsList } from '@components/list/platforms'
 import Modal from '@containers/modals/app'
 import Head from '@containers/head'
-import { selectApiServer } from '@stores/apps/selectors'
+import { selectRankedBlockstackApps } from '@stores/apps/selectors'
 
 class HomePage extends React.PureComponent {
   static async getInitialProps({ req, reduxStore }) {
-    const api = selectApiServer(reduxStore.getState())
-    let props = {}
-    try {
-      const promises = await Promise.all([
-        fetch(`${api}/api/app-mining-months`),
-        fetch(`${api}/api/mining-faq`),
-        fetch(`${api}/api/app-mining-apps`)
-      ])
-      const { months } = await promises[0].json()
-      const { faqs } = await promises[1].json()
-      const { apps } = await promises[2].json()
-
-      if (months && months.length) {
-        const rankings = months[months.length - 1].compositeRankings.map((app) => {
-          const appWithLifetimeEarnings = apps.find((otherApp) => otherApp.name === app.name)
-          return {
-            ...appWithLifetimeEarnings,
-            ...app
-          }
-        })
-        props = { rankings, month: months[months.length - 1], months, faq: faqs, apps }
-      } else {
-        props = {}
-      }
-    } catch (error) {
-      props = {}
-    }
+    const rankings = selectRankedBlockstackApps(reduxStore.getState())
+    const props = { rankings }
 
     if (req) {
       const {

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ if (dev) {
 }
 
 const { ssrCache } = require('./common/lib/cache')
-const { getApps, getAppMiningMonths } = require('./common/lib/api')
+const { getApps, getAppMiningMonths, getRankedBlockstackApps } = require('./common/lib/api')
 const getSitemapURLs = require('./common/lib/sitemap')
 const RSSController = require('./common/controllers/rss-controller')
 const slugify = require('./common/lib/slugify')
@@ -27,7 +27,10 @@ const apiServer = process.env.API_SERVER || 'https://api.app.co'
 
 async function renderAndCache(req, res, pagePath, serverData) {
   try {
-    const data = await getApps(apiServer)
+    const [data, blockstackRankedApps] = await Promise.all([
+      getApps(apiServer),
+      getRankedBlockstackApps(apiServer)
+    ])
     data.apiServer = apiServer
     let appMiningMonths = []
     if (serverData && serverData.fetchMiningResults) {
@@ -37,6 +40,7 @@ async function renderAndCache(req, res, pagePath, serverData) {
     const dataToPass = {
       ...data,
       ...serverData,
+      blockstackRankedApps,
       appMiningMonths
     }
     const html = await app.renderToHTML(req, res, pagePath, dataToPass)

--- a/stores/apps/selectors.js
+++ b/stores/apps/selectors.js
@@ -33,6 +33,8 @@ export const selectAppConstants = (state) => state.apps && state.apps.constants.
 
 export const selectAppMiningApps = (state) => state.apps && state.apps.appMiningApps
 
+export const selectRankedBlockstackApps = (state) => state.apps && state.apps.blockstackRankedApps
+
 export const selectAllPlatforms = (state) => {
   if (!state.apps || !state.apps.platforms) {
     state.apps.platforms = state.platforms


### PR DESCRIPTION
This PR moves the logic for fetching app mining apps to the server, and caches it, just like we do with apps. This will make the home page much faster. This is a pattern we could use on a few other apps, too, but I'm not sure we need to do them all at once.

I think we should try re-adding logic to cache HTML rendering on the server, which we used to have, but removed it for some reason.