### PR TITLE
Adds route to send users to latest mining results

### DIFF
--- a/common/lib/api.js
+++ b/common/lib/api.js
@@ -6,6 +6,7 @@ const { ssrCache } = require('./cache')
 const dev = process.env.NODE_ENV !== 'production'
 const API_CACHE_KEY = 'API_CACHE_KEY'
 const BLOCKSTACK_RANKED_APPS_KEY = 'BLOCKSTACK_RANKED_APPS_KEY'
+const MINING_RESULTS_KEY = 'MINING_RESULTS_KEY'
 
 const processApps = (appsData) => {
   let categories = Object.keys(appsData.constants.appConstants.categoryEnums)
@@ -64,14 +65,19 @@ const getApps = (apiServer) =>
 const getAppMiningMonths = (apiServer) =>
   new Promise(async (resolve, reject) => {
     try {
+      if (ssrCache.has(MINING_RESULTS_KEY)) {
+        return resolve(JSON.parse(ssrCache.get(MINING_RESULTS_KEY)))
+      }
       const { months } = await request({
         uri: `${apiServer}/api/app-mining-months`,
         json: true
       })
+
+      ssrCache.set(MINING_RESULTS_KEY, JSON.stringify(months))
       return resolve(months)
     } catch (error) {
       console.log('Error when fetching mining months', error)
-      reject(error)
+      return reject(error)
     }  
   })
 

--- a/server.js
+++ b/server.js
@@ -108,6 +108,20 @@ app.prepare().then(() => {
       renderAndCache(req, res, '/mining/developer-instructions')
     )
     server.get('/mining/reviewer-instructions', (req, res) => renderAndCache(req, res, '/mining/reviewer-instructions'))
+
+    server.get('/mining/latest', async (req, res) => {
+      try {
+        const months = await getAppMiningMonths(apiServer)
+        const latest = months[months.length - 1]
+        const slug = slugify(latest.humanReadableDate)
+        res.redirect(`/mining/${slug}`)
+      } catch (error) {
+        console.error(error)
+        res.redirect('/mining')
+      }
+    })
+
+
     server.get('/mining/:date', (req, res) => {
       const { date } = req.params
       const [month, year] = date.split('-')


### PR DESCRIPTION
With this PR, you can always visit `/mining/latest`, and you'll get redirected to the latest results page.