### PR TITLE
use SSR caching

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,10 @@ async function renderAndCache(req, res, pagePath, serverData) {
   try {
     const cacheKey = pageCacheKey(req)
     if (cacheKey && ssrCache.has(cacheKey) && !dev) {
+      console.log('Cache hit:', req.path)
       res.send(ssrCache.get(cacheKey))
+    } else {
+      console.log('Cache miss:', req.path)
     }
     const [data, blockstackRankedApps] = await Promise.all([
       getApps(apiServer),


### PR DESCRIPTION
This adds SSR caching to all non-admin pages on app.co. Although we already cache some external API calls, this will by default cache all page renders, and further improve performance.