### PR TITLE
Display and modify STX payout information for app mining

### DIFF
--- a/pages/admin/mining/month.js
+++ b/pages/admin/mining/month.js
@@ -8,6 +8,7 @@ import Link from 'next/link'
 import { Box } from 'blockstack-ui'
 import Router from 'next/router'
 import download from 'downloadjs'
+import { CheckboxStateless as Checkbox } from '@atlaskit/checkbox'
 
 import MiningActions from '@stores/mining-admin/actions'
 
@@ -26,6 +27,10 @@ class MiningMonth extends React.Component {
     purchaseExchangeName: '',
     BTCTransactionId: '',
     purchaseConversionRate: '',
+    stxPayoutTotal: '',
+    stxPayoutDecay: '',
+    stxPayoutConversionRate: 0.3,
+    stxPayoutIsIOU: false,
     status: '',
     name: ''
   }
@@ -232,6 +237,63 @@ class MiningMonth extends React.Component {
                     <Input type="text"
                       value={this.state.BTCTransactionId}
                       onChange={(evt) => this.setState({ BTCTransactionId: evt.target.value })}
+                    />
+                  </FormTd>
+                </tr>
+              </tbody>
+            </Table>
+            <Button onClick={() => this.save()}>Save</Button>
+          </div>
+        </Collapsable>
+
+        <Collapsable title="STX Payout">
+          <div style={{ paddingBottom: '1em' }}>
+            <Table>
+              <tbody>
+                <tr>
+                  <FormTd>
+                    STX Payout Total
+                  </FormTd>
+                  <FormTd textAlign="right">
+                    <Input
+                      type="number"
+                      value={this.state.stxPayoutTotal}
+                      onChange={(evt) => this.setState({ stxPayoutTotal: evt.target.value })}
+                    />
+                  </FormTd>
+                </tr>
+                <tr>
+                  <FormTd>
+                    STX Payout Decay Rate (%)
+                  </FormTd>
+                  <FormTd textAlign="right">
+                    <Input
+                      type="number"
+                      value={this.state.stxPayoutDecay}
+                      onChange={(evt) => this.setState({ stxPayoutDecay: evt.target.value })}
+                    />
+                  </FormTd>
+                </tr>
+                <tr>
+                  <FormTd>
+                    STX Payout Conversion Rate to USD
+                  </FormTd>
+                  <FormTd textAlign="right">
+                    <Input type="number"
+                      value={this.state.stxPayoutConversionRate}
+                      onChange={(evt) => this.setState({ stxPayoutConversionRate: evt.target.value })}
+                    />
+                  </FormTd>
+                </tr>
+                <tr>
+                  <FormTd>
+                    STX Payout is an IOU
+                  </FormTd>
+                  <FormTd textAlign="right">
+                    <Checkbox
+                      isChecked={this.state.stxPayoutIsIOU}
+                      onChange={() => this.setState({ stxPayoutIsIOU: !this.state.stxPayoutIsIOU })}
+                      label="STX Payout is an IOU"
                     />
                   </FormTd>
                 </tr>

--- a/pages/mining/month-results.js
+++ b/pages/mining/month-results.js
@@ -83,7 +83,9 @@ class MonthResults extends React.Component {
             <>
               {app.formattedUsdRewards}
               <SubReward>({app.payout.BTCPaymentValue / 10e7} BTC)</SubReward>
-              <SubReward>({app.formattedSTXRewards} STX)</SubReward>
+              {app.formattedSTXRewards && (
+                <SubReward>({app.formattedSTXRewards} STX)</SubReward>
+              )}
             </>
           )}
         </SpacedTd>

--- a/pages/mining/month-results.js
+++ b/pages/mining/month-results.js
@@ -11,16 +11,19 @@ import { AppIcon } from '@components/app-icon'
 import { ButtonLink } from '@components/mining-admin/collapsable'
 import Reviewer from '@components/mining/reviewer'
 import Modal from '@containers/modals/app'
+import { selectAppMiningMonths } from '@stores/apps/selectors'
 
 import AppStore from '@stores/apps'
 
 class MonthResults extends React.Component {
   static async getInitialProps(context) {
     const { month, year } = context.query
+    const state = context.reduxStore.getState()
 
     try {
-      const response = await fetch(`https://api.app.co/api/app-mining-months`)
-      const { months } = await response.json()
+      // const response = await fetch(`https://api.app.co/api/app-mining-months`)
+      // const { months } = await response.json()
+      const months = selectAppMiningMonths(state)
       const foundReport = months.find(
         (report) => report.monthName.toLowerCase() === month.toLowerCase() && report.year === parseInt(year, 10)
       )
@@ -44,6 +47,8 @@ class MonthResults extends React.Component {
 
   rankings() {
     const { report } = this.props
+
+    console.log(report.compositeRankings[0])
 
     return report.compositeRankings.map((app, index) => (
       <ClickableTr>
@@ -78,6 +83,7 @@ class MonthResults extends React.Component {
             <>
               {app.formattedUsdRewards}
               <SubReward>({app.payout.BTCPaymentValue / 10e7} BTC)</SubReward>
+              <SubReward>({app.formattedSTXRewards} STX)</SubReward>
             </>
           )}
         </SpacedTd>


### PR DESCRIPTION
This PR implements the ability to add STX payout information to a month for App Mining. If that information is present, it also displays information on the mining results page.

To test:

- Can update payout info on the mining page in admin
  - View a mining page in the admin portal, and update information in the 'STX Payouts' section. After refreshing, the information should show up correctly as you entered it.
- On the results page (i.e. /mining/august-2019) it shows the relevant STX info, if present
  - For each app, the STX amount should show up correctly, based on the conversion rate and decay rate
  - The USD rewards reflects the BTC + STX payout
- The total USD rewards includes STX payouts. This is on the results page, but also on pages like `/mining`
  - The 'total rewards' in the top right should be the BTC amount (roughly $100k, not exact), plus the STX total
  - On `/mining` the rewards for apps should be BTC + STX  