### PR TITLE
Adds Blockstack auth to submission page

### DIFF
--- a/containers/submit/form-section.js
+++ b/containers/submit/form-section.js
@@ -1,0 +1,129 @@
+import React from 'react'
+import { Flex, Box, Field } from 'blockstack-ui'
+import { Select } from '@components/mining/select'
+
+export const FormSection = ({ state, fields, handleChange, errors, message, setState }) => (
+  <>
+    {fields.map((field) => {
+      if (field.type === 'radio') {
+        if (!field.options || field.options.length !== 2) {
+          console.log('Radio type fields need 2 options (true/false)')
+          return null
+        }
+        return (
+          <React.Fragment key={`radio-${field.name}`}>
+            <Field.LabelAdvanced
+              pb={3}
+              label={field.label}
+              required={field.required}
+              error={errors && field && errors[field.name] && errors[field.name]}
+            />
+            <Box pb={4}>
+              {field.options.map((option) => (
+                <Flex pb={3} alignItems="center" key={`radio-${field.name}-${option.value}`}>
+                  <input
+                    type="radio"
+                    name={field.name}
+                    value={option.value}
+                    defaultChecked={String(option.value) === state[field.name] || undefined}
+                    id={String(option.value)}
+                    onChange={(e) => handleChange(e)(setState)}
+                  />
+                  <Field.Label pb={0} pl={2} is="label" htmlFor={String(option.value)}>
+                    {option.label}
+                  </Field.Label>
+                </Flex>
+              ))}
+            </Box>
+          </React.Fragment>
+        )
+      }
+      if (field.type === 'select') {
+        const selectProps = { ...field }
+        if (!!state[field.name]) {
+          selectProps.defaultValue = { label: state[field.name], value: state[field.name] }
+        }
+        return (
+          <React.Fragment key={`select-${field.name}`}>
+            <Box pb={4}>
+              <Field.LabelAdvanced
+                pb={3}
+                required={field.required}
+                hint={field.hint}
+                message={field.message}
+                label={field.label}
+                error={errors && field && errors[field.name] && errors[field.name]}
+              />
+              <Flex pb={3} alignItems="center">
+                <Select
+                  onChange={(e) =>
+                    handleChange({
+                      target: {
+                        name: field.name,
+                        value: e ? e.value : null
+                      }
+                    })(setState)
+                  }
+                  error={errors && field && errors[field.name] && errors[field.name]}
+                  isClearable
+                  {...selectProps}
+                />
+              </Flex>
+            </Box>
+          </React.Fragment>
+        )
+      }
+      if (field.type === 'checkbox') {
+        return (
+          <React.Fragment key={`checkbox-${field.name}`}>
+            <Box pb={4}>
+              <Flex pb={3} alignItems="center">
+                <input
+                  type="checkbox"
+                  name={field.name}
+                  id={field.name}
+                  defaultChecked={!!state[field.name] || undefined}
+                  onChange={(e) =>
+                    handleChange({
+                      persist: e.persist,
+                      target: {
+                        name: e.target.name,
+                        value: e.target.checked
+                      }
+                    })(setState)
+                  }
+                />
+                <Field.LabelAdvanced
+                  labelProps={{
+                    pb: !!(errors && field && errors[field.name]) ? 2 : 0,
+                    htmlFor: field.name
+                  }}
+                  pl={2}
+                  required={field.required}
+                  label={field.label}
+                  error={errors && field && errors[field.name]}
+                />
+              </Flex>
+              {field.message ? (
+                <Field.Message maxWidth={400} lineHeight={1.5}>
+                  {field.message}
+                </Field.Message>
+              ) : null}
+            </Box>
+          </React.Fragment>
+        )
+      }
+      return (
+        <Field
+          noValidate="novalidate"
+          onChange={(e) => handleChange(e)(setState)}
+          key={`field-${field.name}`}
+          defaultValue={state[field.name]}
+          error={errors && field && errors[field.name] && errors[field.name]}
+          {...field}
+        />
+      )
+    })}
+    {message ? <Box pb={4}>{message}</Box> : null}
+  </>
+)

--- a/containers/submit/index.js
+++ b/containers/submit/index.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Type, Flex, Box } from 'blockstack-ui'
+import { AlertOutlineIcon } from 'mdi-react'
+
+export { FormSection } from './form-section'
+export { sections } from './sections'
+
+export const ErrorMessage = ({
+  message = `Whoops! Please check the form for errors and try again.`,
+  icon: Icon = AlertOutlineIcon,
+  ...rest
+}) => (
+  <Flex
+    boxShadow="card"
+    alignItems="center"
+    borderRadius={6}
+    border={1}
+    borderColor="red"
+    py={4}
+    px={4}
+    mb={6}
+    {...rest}
+  >
+    <Box color="red" pr={3}>
+      <Icon />
+    </Box>
+    <Type lineHeight={1.75}>{message}</Type>
+  </Flex>
+)
+
+export const Bar = ({ ...rest }) => <Box width={80} mb={7} mt={5} height="1px" bg="blue.mid" {...rest} />

--- a/containers/submit/sections.js
+++ b/containers/submit/sections.js
@@ -1,0 +1,221 @@
+import React from 'react'
+import { Type } from 'blockstack-ui'
+import { string, boolean } from 'yup'
+
+export const sections = (user, appConstants) => {
+  const personal = [
+    {
+      name: 'isSubmittingOwnApp',
+      required: true,
+      type: 'radio',
+      label: 'Did you build this app?',
+      options: [
+        {
+          label: 'Yes, I built this app.',
+          value: true,
+          checked: true
+        },
+        {
+          label: 'No, I want to add an app someone else built.',
+          value: false
+        }
+      ],
+      validation: boolean().required('Required.')
+    },
+    {
+      name: 'submitterName',
+      required: true,
+      label: 'Your Name',
+      placeholder: 'Satoshi Nakamoto',
+      validation: string().required('Your name is required.')
+    },
+    {
+      name: 'contactEmail',
+      required: true,
+      label: 'Your Email',
+      type: 'email',
+      placeholder: 'satoshi@gmail.com',
+      validation: string()
+        .email('Please enter a valid email.')
+        .required('Your email is required.')
+    },
+    {
+      name: 'referralSource',
+      required: false,
+      label: 'How did you learn about App.co or App Mining?',
+      placeholder: 'Hacker News'
+    }
+  ]
+
+  if (user && user.jwt) {
+    // If the user is logged in, remove the "Is this your app?" question
+    personal.splice(0, 1)
+  }
+
+  const appDetails = [
+    {
+      name: 'name',
+      required: true,
+      label: 'App Name',
+      placeholder: 'Satoshi Chat',
+      validation: string().required('Please enter the app name.')
+    },
+    {
+      name: 'description',
+      required: true,
+      label: 'Short description',
+      hint: 'Max 50 char.',
+      message: 'Will appear on App.co category pages and search.',
+      placeholder: 'A chat app for crypto.',
+      maxLength: 50,
+      validation: string().required('Please enter a short description.')
+    },
+    {
+      name: 'website',
+      required: true,
+      label: 'Website',
+      type: 'url',
+      placeholder: 'https://satoshi.chat/',
+      validation: string()
+        .required('Please enter a website.')
+        .url('Must be a valid URL with http/https.')
+    },
+    {
+      name: 'imageUrl',
+      required: true,
+      label: 'App icon URL',
+      type: 'url',
+      message: 'Square icon, other sizes will be distorted. Accepted formats: JPG, PNG, SVG.',
+      placeholder: 'https://example.com/app_icon.png',
+      validation: string()
+        .required('Please provide an icon.')
+        .url('Must be a valid URL with http/https.')
+    },
+    {
+      name: 'openSourceUrl',
+      required: false,
+      label: 'Open source URL',
+      type: 'url',
+      placeholder: 'https://github.com/SatoshiChat',
+      validation: string().url('Must be a valid URL with http/https.')
+    },
+    {
+      name: 'twitterHandle',
+      required: false,
+      label: "Application's Twitter handle",
+      placeholder: '@SatoshiChat'
+    }
+  ]
+
+  const generateOptions = (enums) =>
+    Object.keys(enums)
+      .sort((a, b) => {
+        if (a.toLowerCase() !== b.toLowerCase()) {
+          return a.toLowerCase() < b.toLowerCase() ? -1 : 1
+        }
+        return 0
+      })
+      .map((opt) => ({ label: opt, value: opt }))
+
+  const categoryOptions = {
+    category: generateOptions(appConstants.categoryEnums),
+    blockchain: generateOptions(appConstants.blockchainEnums),
+    storageNetwork: generateOptions(appConstants.storageEnums),
+    authentication: generateOptions(appConstants.authenticationEnums)
+  }
+
+  const appCategories = [
+    {
+      name: 'category',
+      required: true,
+      label: 'Category',
+      width: '100%',
+      type: 'select',
+      placeholder: 'Social networking',
+      options: categoryOptions.category,
+      validation: string().required('Please select a category.')
+    },
+    {
+      name: 'blockchain',
+      label: 'Blockchain',
+      width: '100%',
+      type: 'select',
+      placeholder: 'Bitcoin',
+      options: categoryOptions.blockchain
+    },
+    {
+      name: 'storageNetwork',
+      label: 'Storage',
+      width: '100%',
+      type: 'select',
+      placeholder: 'IPFS',
+      options: categoryOptions.storageNetwork
+    },
+    {
+      name: 'authentication',
+      label: 'Authentication',
+      width: '100%',
+      type: 'select',
+      placeholder: 'Blockstack',
+      options: categoryOptions.authentication,
+      message: 'Blockstack authentication is required to qualify for App Mining.'
+    }
+  ]
+
+  const agreements = [
+    {
+      name: 'public',
+      required: true,
+      type: 'checkbox',
+      label: 'App is publicly accessible and user-ready',
+      message:
+        'App.co lists decentralized apps that are user-ready. Part of our review process is verifying anyone can immediately begin using the app.',
+      validation: boolean().required('Required.')
+    },
+    {
+      name: 'disclaimers',
+      required: true,
+      type: 'checkbox',
+      label: (
+        <>
+          I agree to the{' '}
+          <Type is="a" href="/terms" target="_blank">
+            App.co Terms
+          </Type>
+          ,{' '}
+          <Type is="a" href="/privacy" target="_blank">
+            Privacy Policy
+          </Type>
+          , and{' '}
+          <Type is="a" href="/mining/terms" target="_blank">
+            App Mining Terms
+          </Type>
+          .
+        </>
+      ),
+      validation: boolean().required('To submit an app, you must accept these terms.')
+    }
+  ]
+
+  const sections = [
+    {
+      fields: personal
+    },
+    {
+      fields: appDetails
+    },
+    {
+      fields: appCategories,
+      message: (
+        <>
+          Want to add a new category, blockchain, storage, or technology?{' '}
+          <a href="mailto:hello@app.co">Contact us.</a>
+        </>
+      )
+    },
+    {
+      fields: agreements
+    }
+  ]
+  return sections
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -10,6 +10,8 @@ import { theme } from '@common/styles'
 import { theme as BlockstackTheme } from 'blockstack-ui'
 import { ThemeProvider, createGlobalStyle } from 'styled-components'
 import { Mdx } from '@components/mdx'
+import NProgress from 'nprogress'
+import routerEvents from 'next-router-events'
 import { trackPageView } from '@utils'
 import 'isomorphic-unfetch'
 import { normalize } from 'polished'
@@ -86,6 +88,13 @@ class MyApp extends App {
     }
 
     return { pageProps, cookies }
+  }
+
+  constructor(props) {
+    super(props)
+    routerEvents.on('routeChangeStart', () => NProgress.start())
+    routerEvents.on('routeChangeComplete', () => NProgress.done())
+    routerEvents.on('routeChangeError', () => NProgress.done())
   }
 
   componentDidMount() {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -62,6 +62,7 @@ export default class MyDocument extends Document {
             data-user="48381"
             async
           />
+          <link href="/static/nprogress.css" rel="stylesheet" type="text/css" async />
           {this.props.styleTags}
         </Head>
         <body>

--- a/pages/submit.js
+++ b/pages/submit.js
@@ -276,7 +276,7 @@ class SubmitDapp extends React.Component {
                   <Type display="block">Thanks for your submission! Your app will need to be approved before being public on app.co.</Type>
                   {this.appMiningEligible() && (
                     <>
-                      <Type mt={2} display="block">To update your app&apos;s details and enroll in App Mining, visit our Maker Portal</Type>
+                      <Type my={3} display="block">To update your app&apos;s details and enroll in App Mining, visit our Maker Portal</Type>
                       <Link
                         href={{
                           pathname: '/maker'

--- a/pages/submit.js
+++ b/pages/submit.js
@@ -8,38 +8,13 @@ import { Page } from '@components/page'
 import { Type, Field, Flex, Box, Button } from 'blockstack-ui'
 import { selectAppConstants, selectApiServer } from '@stores/apps/selectors'
 import { string, boolean } from 'yup'
-import { Select } from '@components/mining/select'
-import { AlertOutlineIcon } from 'mdi-react'
+import { FormSection, ErrorMessage, Bar, sections as getSections } from '@containers/submit'
 import debounce from 'lodash.debounce'
 import UserStore from '@stores/user'
 
 import { trackEvent } from '@utils'
 
 const APP_SUBMISSION_DATA = 'app_submission_data'
-
-const ErrorMessage = ({
-  message = `Whoops! Please check the form for errors and try again.`,
-  icon: Icon = AlertOutlineIcon,
-  ...rest
-}) => (
-  <Flex
-    boxShadow="card"
-    alignItems="center"
-    borderRadius={6}
-    border={1}
-    borderColor="red"
-    py={4}
-    px={4}
-    mb={6}
-    {...rest}
-  >
-    <Box color="red" pr={3}>
-      <Icon />
-    </Box>
-    <Type lineHeight={1.75}>{message}</Type>
-  </Flex>
-)
-const Bar = ({ ...rest }) => <Box width={80} mb={7} mt={5} height="1px" bg="blue.mid" {...rest} />
 
 const outerHandleChange = (e) => (setState) => {
   if (e && e.persist) e.persist()
@@ -52,349 +27,8 @@ const outerHandleChange = (e) => (setState) => {
   }))
 }
 
-const FormSection = ({ state, fields, handleChange, errors, message, setState }) => (
-  <>
-    {fields.map((field) => {
-      if (field.type === 'radio') {
-        if (!field.options || field.options.length !== 2) {
-          console.log('Radio type fields need 2 options (true/false)')
-          return null
-        }
-        return (
-          <React.Fragment key={`radio-${field.name}`}>
-            <Field.LabelAdvanced
-              pb={3}
-              label={field.label}
-              required={field.required}
-              error={errors && field && errors[field.name] && errors[field.name]}
-            />
-            <Box pb={4}>
-              {field.options.map((option) => (
-                  <Flex pb={3} alignItems="center" key={`radio-${field.name}-${option.value}`}>
-                    <input
-                      type="radio"
-                      name={field.name}
-                      value={option.value}
-                      defaultChecked={String(option.value) === state[field.name] || undefined}
-                      id={String(option.value)}
-                      onChange={(e) => handleChange(e)(setState)}
-                    />
-                    <Field.Label pb={0} pl={2} is="label" htmlFor={String(option.value)}>
-                      {option.label}
-                    </Field.Label>
-                  </Flex>
-                ))}
-            </Box>
-          </React.Fragment>
-        )
-      }
-      if (field.type === 'select') {
-        const selectProps = { ...field }
-        if (!!state[field.name]) {
-          selectProps.defaultValue = { label: state[field.name], value: state[field.name] }
-        }
-        return (
-          <React.Fragment key={`select-${field.name}`}>
-            <Box pb={4}>
-              <Field.LabelAdvanced
-                pb={3}
-                required={field.required}
-                hint={field.hint}
-                message={field.message}
-                label={field.label}
-                error={errors && field && errors[field.name] && errors[field.name]}
-              />
-              <Flex pb={3} alignItems="center">
-                <Select
-                  onChange={(e) =>
-                    handleChange({
-                      target: {
-                        name: field.name,
-                        value: e ? e.value : null
-                      }
-                    })(setState)
-                  }
-                  error={errors && field && errors[field.name] && errors[field.name]}
-                  isClearable
-                  {...selectProps}
-                />
-              </Flex>
-            </Box>
-          </React.Fragment>
-        )
-      }
-      if (field.type === 'checkbox') {
-        return (
-          <React.Fragment key={`checkbox-${field.name}`}>
-            <Box pb={4}>
-              <Flex pb={3} alignItems="center">
-                <input
-                  type="checkbox"
-                  name={field.name}
-                  id={field.name}
-                  defaultChecked={!!state[field.name] || undefined}
-                  onChange={(e) =>
-                    handleChange({
-                      persist: e.persist,
-                      target: {
-                        name: e.target.name,
-                        value: e.target.checked
-                      }
-                    })(setState)
-                  }
-                />
-                <Field.LabelAdvanced
-                  labelProps={{
-                    pb: !!(errors && field && errors[field.name]) ? 2 : 0,
-                    htmlFor: field.name
-                  }}
-                  pl={2}
-                  required={field.required}
-                  label={field.label}
-                  error={errors && field && errors[field.name]}
-                />
-              </Flex>
-              {field.message ? (
-                <Field.Message maxWidth={400} lineHeight={1.5}>
-                  {field.message}
-                </Field.Message>
-              ) : null}
-            </Box>
-          </React.Fragment>
-        )
-      }
-      return (
-        <Field
-          noValidate="novalidate"
-          onChange={(e) => handleChange(e)(setState)}
-          key={`field-${field.name}`}
-          defaultValue={state[field.name]}
-          error={errors && field && errors[field.name] && errors[field.name]}
-          {...field}
-        />
-      )
-    })}
-    {message ? <Box pb={4}>{message}</Box> : null}
-
-    <Bar />
-  </>
-)
-
 const Submit = ({ appConstants, setState, state, errors, submit, user, loading, signIn, isAppMiningEligible }) => {
-  const personal = [
-    {
-      name: 'isSubmittingOwnApp',
-      required: true,
-      type: 'radio',
-      label: 'Did you build this app?',
-      options: [
-        {
-          label: 'Yes, I built this app.',
-          value: true,
-          checked: true
-        },
-        {
-          label: 'No, I want to add an app someone else built.',
-          value: false
-        }
-      ],
-      validation: boolean().required('Required.')
-    },
-    {
-      name: 'submitterName',
-      required: true,
-      label: 'Your Name',
-      placeholder: 'Satoshi Nakamoto',
-      validation: string().required('Your name is required.')
-    },
-    {
-      name: 'contactEmail',
-      required: true,
-      label: 'Your Email',
-      type: 'email',
-      placeholder: 'satoshi@gmail.com',
-      validation: string()
-        .email('Please enter a valid email.')
-        .required('Your email is required.')
-    },
-    {
-      name: 'referralSource',
-      required: false,
-      label: 'How did you learn about App.co or App Mining?',
-      placeholder: 'Hacker News'
-    }
-  ]
-
-  console.log(user)
-  if (user && user.jwt) {
-    // If the user is logged in, remove the "Is this your app?" question
-    personal.splice(0,1)
-  }
-
-  const appDetails = [
-    {
-      name: 'name',
-      required: true,
-      label: 'App Name',
-      placeholder: 'Satoshi Chat',
-      validation: string().required('Please enter the app name.')
-    },
-    {
-      name: 'description',
-      required: true,
-      label: 'Short description',
-      hint: 'Max 50 char.',
-      message: 'Will appear on App.co category pages and search.',
-      placeholder: 'A chat app for crypto.',
-      maxLength: 50,
-      validation: string().required('Please enter a short description.')
-    },
-    {
-      name: 'website',
-      required: true,
-      label: 'Website',
-      type: 'url',
-      placeholder: 'https://satoshi.chat/',
-      validation: string()
-        .required('Please enter a website.')
-        .url('Must be a valid URL with http/https.')
-    },
-    {
-      name: 'imageUrl',
-      required: true,
-      label: 'App icon URL',
-      type: 'url',
-      message: 'Square icon, other sizes will be distorted. Accepted formats: JPG, PNG, SVG.',
-      placeholder: 'https://example.com/app_icon.png',
-      validation: string()
-        .required('Please provide an icon.')
-        .url('Must be a valid URL with http/https.')
-    },
-    {
-      name: 'openSourceUrl',
-      required: false,
-      label: 'Open source URL',
-      type: 'url',
-      placeholder: 'https://github.com/SatoshiChat',
-      validation: string().url('Must be a valid URL with http/https.')
-    },
-    {
-      name: 'twitterHandle',
-      required: false,
-      label: "Application's Twitter handle",
-      placeholder: '@SatoshiChat'
-    }
-  ]
-
-  const generateOptions = (enums) =>
-    Object.keys(enums)
-      .sort((a, b) => {
-        if (a.toLowerCase() !== b.toLowerCase()) {
-          return a.toLowerCase() < b.toLowerCase() ? -1 : 1
-        }
-        return 0
-      })
-      .map((opt) => ({ label: opt, value: opt }))
-
-  const categoryOptions = {
-    category: generateOptions(appConstants.categoryEnums),
-    blockchain: generateOptions(appConstants.blockchainEnums),
-    storageNetwork: generateOptions(appConstants.storageEnums),
-    authentication: generateOptions(appConstants.authenticationEnums)
-  }
-
-  const appCategories = [
-    {
-      name: 'category',
-      required: true,
-      label: 'Category',
-      width: '100%',
-      type: 'select',
-      placeholder: 'Social networking',
-      options: categoryOptions.category,
-      validation: string().required('Please select a category.')
-    },
-    {
-      name: 'blockchain',
-      label: 'Blockchain',
-      width: '100%',
-      type: 'select',
-      placeholder: 'Bitcoin',
-      options: categoryOptions.blockchain
-    },
-    {
-      name: 'storageNetwork',
-      label: 'Storage',
-      width: '100%',
-      type: 'select',
-      placeholder: 'IPFS',
-      options: categoryOptions.storageNetwork
-    },
-    {
-      name: 'authentication',
-      label: 'Authentication',
-      width: '100%',
-      type: 'select',
-      placeholder: 'Blockstack',
-      options: categoryOptions.authentication,
-      message: 'Blockstack authentication is required to qualify for App Mining.'
-    }
-  ]
-
-  const agreements = [
-    {
-      name: 'public',
-      required: true,
-      type: 'checkbox',
-      label: 'App is publicly accessible and user-ready',
-      message:
-        'App.co lists decentralized apps that are user-ready. Part of our review process is verifying anyone can immediately begin using the app.',
-      validation: boolean().required('Required.')
-    },
-    {
-      name: 'disclaimers',
-      required: true,
-      type: 'checkbox',
-      label: (
-        <>
-          I agree to the{' '}
-          <Type is="a" href="/terms" target="_blank">
-            App.co Terms
-          </Type>
-          ,{' '}
-          <Type is="a" href="/privacy" target="_blank">
-            Privacy Policy
-          </Type>
-          , and{' '}
-          <Type is="a" href="/mining/terms" target="_blank">
-            App Mining Terms
-          </Type>
-          .
-        </>
-      ),
-      validation: boolean().required('To submit an app, you must accept these terms.')
-    }
-  ]
-
-  const sections = [
-    {
-      fields: personal
-    },
-    {
-      fields: appDetails
-    },
-    {
-      fields: appCategories,
-      message: (
-        <>
-          Want to add a new category, blockchain, storage, or technology? <a href="mailto:hello@app.co">Contact us.</a>
-        </>
-      )
-    },
-    {
-      fields: agreements
-    }
-  ]
+  const sections = getSections(user, appConstants)
 
   const validate = async () => {
     let errorsObj = {}
@@ -488,15 +122,18 @@ const Submit = ({ appConstants, setState, state, errors, submit, user, loading, 
       <Flex flexWrap="wrap" pt={6} flexDirection="column">
         <form noValidate onSubmit={handleValidation}>
           {sections.map((section) => (
-            <FormSection
-              errors={errors}
-              handleChange={outerHandleChange}
-              setState={setState}
-              key={`section-${section.fields[0].name}`}
-              message={section.message}
-              fields={section.fields}
-              state={state}
-            />
+            <>
+              <FormSection
+                errors={errors}
+                handleChange={outerHandleChange}
+                setState={setState}
+                key={`section-${section.fields[0].name}`}
+                message={section.message}
+                fields={section.fields}
+                state={state}
+              />
+              <Bar />
+            </>
           ))}
           {errors ? <ErrorMessage /> : null}
           {isAppMiningEligible && !(user && user.jwt) ? (

--- a/pages/submit.js
+++ b/pages/submit.js
@@ -136,8 +136,13 @@ const Submit = ({ appConstants, setState, state, errors, submit, user, loading, 
             </>
           ))}
           {errors ? <ErrorMessage /> : null}
-          {isAppMiningEligible && !(user && user.jwt) ? (
-            <Button onClick={blockstackAuth}>{loading ? 'Loading...' : 'Login with Blockstack'}</Button>
+          {!(user && user.jwt) ? (
+            <>
+              <Field.Message maxWidth={400} lineHeight={1.5} mb={3}>
+                To submit your app, first login with Blockstack. You&apos;ll be able to use your Blockstack ID to manage your app&apos;s listing.
+              </Field.Message>
+              <Button onClick={blockstackAuth}>{loading ? 'Loading...' : 'Login with Blockstack'}</Button>
+            </>
           ) : (
             <Button>{loading ? 'Loading...' : 'Submit App'}</Button>
           )}
@@ -152,8 +157,6 @@ const getValues = () => {
     const appDataJSON = localStorage.getItem(APP_SUBMISSION_DATA)
     if (appDataJSON) {
       const appData = JSON.parse(appDataJSON)
-      console.log('from localStorage', appData)
-      // localStorage.removeItem(APP_SUBMISSION_DATA)
       return appData
     }
   }
@@ -196,19 +199,6 @@ class SubmitDapp extends React.Component {
       }
     }
   }
-  
-  setStateFromLocalStorage = () => {
-    const appDataJSON = localStorage.getItem(APP_SUBMISSION_DATA)
-    if (appDataJSON) {
-      const appData = JSON.parse(appDataJSON)
-      console.log('from localStorage', appData)
-      localStorage.removeItem(APP_SUBMISSION_DATA)
-      return {
-        values: appData
-      }
-    }
-    return {}
-  }
 
   submit = async () => {
     const { apiServer, user } = this.props
@@ -247,6 +237,7 @@ class SubmitDapp extends React.Component {
       })
       const { app } = await response.json()
       trackEvent('App Submission Page - Submission Success')
+      localStorage.removeItem(APP_SUBMISSION_DATA)
       this.setState({ success: true, loading: false, accessToken: app.accessToken })
     } catch (e) {
       trackEvent('App Submission Page - Submission Error')

--- a/pages/submit.js
+++ b/pages/submit.js
@@ -268,7 +268,6 @@ class SubmitDapp extends React.Component {
 
   render() {
     const { appConstants } = this.props
-    const { accessToken } = this.state
 
     return (
       <Page>
@@ -283,29 +282,22 @@ class SubmitDapp extends React.Component {
                   </Type>
                 </Box>
                 <Box mx="auto">
-                  <Type display="block">Thanks for your submission! We&apos;ll get back to you soon.</Type>
+                  <Type display="block">Thanks for your submission! Your app will need to be approved before being public on app.co.</Type>
                   {this.appMiningEligible() && (
                     <>
-                      <Type mt={2} display="block">You can update your app details using this magic link. Don&apos;t share this URL!</Type>
+                      <Type mt={2} display="block">To update your app&apos;s details and enroll in App Mining, visit our Maker Portal</Type>
                       <Link
                         href={{
-                          pathname: '/maker',
-                          query: {
-                            accessToken
-                          }
+                          pathname: '/maker'
                         }}
-                        as={this.makerPortalURL()}
                         passHref
                       >
-                        <Type mt={2} is="a" display="block">{document.location.origin}{this.makerPortalURL()}</Type> 
+                        <Button is="a" href="/" color="white !important">
+                          Go to the Maker Portal
+                        </Button>
                       </Link>
                     </>
                   )}
-                </Box>
-                <Box pt={6}>
-                  <Button is="a" href="/" color="white !important">
-                    Back Home
-                  </Button>
                 </Box>
               </Box>
             </>

--- a/stores/user/index.js
+++ b/stores/user/index.js
@@ -2,7 +2,7 @@ import { UserSession, AppConfig } from 'blockstack'
 
 const host = typeof document === 'undefined' ? 'https://app.co' : document.location.origin
 const appConfig = new AppConfig(['store_write'], host)
-const userSession = new UserSession({ appConfig })
+export const userSession = new UserSession({ appConfig })
 
 const initialState = {
   userId: null,
@@ -29,7 +29,7 @@ const signedIn = (data) => ({
   userId: data.user.id
 })
 
-const signOut = () => ({
+const signOut = () => ({ 
   type: constants.SIGNING_OUT
 })
 
@@ -38,6 +38,9 @@ const handleSignIn = (apiServer) =>
     const token = userSession.getAuthResponseToken()
     if (!token) {
       return true
+    }
+    if (userSession.isUserSignedIn()) {
+      userSession.signUserOut()
     }
 
     dispatch(signingIn())
@@ -48,15 +51,11 @@ const handleSignIn = (apiServer) =>
     })
     const json = await response.json()
     dispatch(signedIn(json))
-    // setTimeout(() => {
-    //   document.location = '/admin'
-    // }, 1000)
-
     return true
   }
 
-const signIn = () => {
-  const redirect = `${window.location.origin}/admin`
+const signIn = (redirectPath = 'admin') => {
+  const redirect = `${window.location.origin}/${redirectPath}`
   const manifest = `${window.location.origin}/static/manifest.json`
   userSession.redirectToSignIn(redirect, manifest)
   return signingIn()


### PR DESCRIPTION
This PR changes the submission page. The new flow is:

- If the user has selected 'Blockstack auth', they see "login with Blockstack" instead of "Submit"
- They can login with Blockstack and come back. Their submission details are stored in `localStorage`, and re-populated when they come back.
- After they come back, they're logged in, and can submit the app
- The submission page passes the logged-in user's info to the API server, so the API server can store that Blockstack ID with the app

This PR also breaks out the submission page into separate files, as it was already a bit large