### PR TITLE
Updates home page sections

### DIFF
--- a/components/navigation/index.js
+++ b/components/navigation/index.js
@@ -26,8 +26,8 @@ const NavigationComponent = ({ handleClick, isErrorPage, openNewsletterModal, fo
         </>
       ) : (
         <>
-          <ErrorPageLink isErrorPage={isErrorPage} href="/all">
-            <a href="/all">All apps</a>
+          <ErrorPageLink isErrorPage={isErrorPage} href={{ pathname: '/platforms', query: { platform: 'blockstack' } }} as="/blockstack">
+            <a href="/blockstack">All apps</a>
           </ErrorPageLink>
           <ErrorPageLink isErrorPage={isErrorPage} href="/faq" prefetch {...extraProps}>
             <a href="/faq">Learn more</a>

--- a/pages/home/index.js
+++ b/pages/home/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page } from '@components/page'
 import { Newsletter } from '@components/newsletter'
-import { FeaturedList, AppsList } from '@components/list/apps'
+import { FeaturedList } from '@components/list/apps'
 import { CategoriesList } from '@components/list/categories'
 import { doSelectApp } from '@stores/apps'
 import { PlatformsList } from '@components/list/platforms'
@@ -48,21 +48,6 @@ class HomePage extends React.PureComponent {
             query="blockstack"
             limit={23}
           />
-          <AppsList
-            single
-            limit={4}
-            filterBy="all"
-            title="Popular Decentralized Apps"
-            header={{
-              action: {
-                label: 'View All'
-              },
-              href: {
-                pathname: '/all'
-              },
-              as: '/all'
-            }}
-          />
         </Page.Section>
 
         <Page.Section p={0} pl={[0, 4]} pr={[0, 4]}>
@@ -72,14 +57,6 @@ class HomePage extends React.PureComponent {
           </Page.Section>
         </Page.Section>
         <Page.Section flexDirection="column" px>
-          <FeaturedList
-            appNames={['MyCrypto', 'MyEtherWallet', 'Balance.io', 'Coinbase Wallet', 'MetaMask', 'Trust Wallet']}
-            title="Ethereum Wallets"
-          />
-          <FeaturedList
-            title="Decentralized Exchanges"
-            appNames={['Airswap', 'EtherDelta', 'Radar Relay', 'IDEX', 'OasisDEX', 'Paradex', 'Dexy']}
-          />
           <FeaturedList
             appNames={['SteemIt', 'Stealthy', 'Peepeth', 'Mastodon', 'Diaspora', 'DTube']}
             title="Hot Social Dapps"


### PR DESCRIPTION
We created the 'new' home page over a year ago, and the last time we touched it was 7 months ago, when we added the 'top Blockstack apps' section, which uses App Mining apps.

The "Top Apps" section has always been bad, because it uses Twitter to rank apps. Since we built this, we started adding Zero-To-Dapp apps, but this breaks the Twitter algo, because they're mostly hosted on Netlify.

Nowadays, the 'Top Blockstack Apps' is a much better way to sort for quality.

I've gone ahead and removed the "Top Apps" section, and also removed "Ethereum Wallets" and "Decentralized Exchanges".

I also changed the 'All Apps' navigation link to go to `/blockstack`, which has the better sorting algorithm.

We can do much better with the home page, now, even just with App Mining data. However, I think these changes provide value without having to do anything new.

Assigning @markmhx to review these UI changes.