### PR TITLE
refactor: Prevent transit key errors by removing query params

### DIFF
--- a/components/maker/nav/maker-nav.tsx
+++ b/components/maker/nav/maker-nav.tsx
@@ -72,6 +72,7 @@ const MakerNavActions = ({ userId, handleSignOut }: MakerNavActionsProps) => {
           fontSize={0}
           fontWeight="medium"
           color="blue.900"
+          cursor="pointer"
         >
           Sign out
         </Text>

--- a/pages/maker/apps/index.tsx
+++ b/pages/maker/apps/index.tsx
@@ -3,6 +3,7 @@ import Head from '@containers/head';
 import { bindActionCreators } from 'redux';
 import { connect, useSelector } from 'react-redux';
 
+import Head from '@containers/head';
 import { AppDirectory } from '@components/app-directory';
 import { Flex, Box } from '@blockstack/ui';
 import { isUserSignedIn } from '@stores/user/selectors';

--- a/pages/submit-your-app.tsx
+++ b/pages/submit-your-app.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import 'isomorphic-unfetch';
 import { Dispatch, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -72,6 +72,7 @@ const Submit: Submit = ({
   isAppMiningEligible
 }) => {
   const sections = getSections(user, appConstants);
+  const [signingIn, setSigningIn] = useState(false);
 
   const validate = async () => {
     let errorsObj = {};
@@ -136,6 +137,7 @@ const Submit: Submit = ({
   };
 
   const blockstackAuth = (e: any) => {
+    setSigningIn(true);
     if (e) {
       e.preventDefault();
     }
@@ -152,7 +154,7 @@ const Submit: Submit = ({
         <section>
           <SubmitSignIn
             handleBlockstackAuth={blockstackAuth}
-            loading={loading}
+            loading={signingIn}
           />
         </section>
       )}
@@ -191,10 +193,16 @@ const Submit: Submit = ({
             />
           ))}
           <WarningCard message="Blockstack Authentication is required to participate in App Mining" />
-          {errors ? <ErrorMessage message={!(user && user.jwt) ? 'You must sign in with Blockstack' : undefined} /> : null}
-          <Button>
-            {loading ? 'Loading...' : 'Submit your app'}
-          </Button>
+          {errors ? (
+            <ErrorMessage
+              message={
+                !(user && user.jwt)
+                  ? 'You must sign in with Blockstack'
+                  : undefined
+              }
+            />
+          ) : null}
+          <Button>{loading ? 'Loading...' : 'Submit your app'}</Button>
         </form>
       </Flex>
     </Box>


### PR DESCRIPTION
The transit key errors being thrown in the console were owing to the parsing of the `authResponse` after a refresh. To ensure this doesn't happen, either by a timed or manual refresh, we remove the query params. 